### PR TITLE
add inclusion tool and how to use it (and the previous tool)

### DIFF
--- a/CONTRIBUTIONS/README.md
+++ b/CONTRIBUTIONS/README.md
@@ -22,3 +22,24 @@ when we combine the use case in a single document.
 - network operator (potentially transparent for WoT use cases)  
 - identity provider  
 - directory service operator?  
+
+# Tools
+
+There are the following three scripts to convert the use case MD files
+into HTML files, and then put them into the main ***index.html*** file.
+
+* ***md2html.sh***: main script to the the above
+* ***md2html.pl***: Perl script called from ***md2html.sh*** and convert each MD file into HTML
+* ***include.pl***: Perl script called from ***md2html.sh*** to include all the expected HTML fragment files into the main ***index.html*** file
+
+## Usage
+
+1. Copy all the three tools above and the main ***index.html*** file to the directory of the MD files to be converted.
+1. Use ***md2html.sh*** script to convert all the MD files into HTML.<br>
+   `$ ./md2html.sh`
+1. Add the command of<br>`#include "your-expected.html"`<br>to the line of ***index.html*** manually to specify where to include which HTML file. You can add multiple #include commands if you want to include multiple HTML files at once.
+1. Then include your expected HTML file(s) into the ***index.html*** file.<br>
+   `$ ./include.pl index.html > index2.html`
+1. Check the resulted ***index2.html*** file. If there are any problems with the inclusion results, please fix them manually.
+1. After fixing all the problems within the ***index2.html*** file, please rename it to ***index.html***.<br>
+   `$ mv index2.html index.html`

--- a/CONTRIBUTIONS/include.pl
+++ b/CONTRIBUTIONS/include.pl
@@ -1,0 +1,34 @@
+#!/usr/bin/perl
+
+my $src = "";
+my $fragment = "";
+
+$src = $ARGV[0];
+
+open(SRC, ${src}) || die "${src}: $!\n";
+while (<SRC>) {
+  chomp;
+
+  if (/^#include "(.*)"/) {
+    ${fragment} = $1;
+    include_fragment($fragment);
+
+  } else {
+    print "$_\n";
+
+  }
+}
+close(SRC);
+
+###
+sub include_fragment ($){
+  my $in = shift;
+
+  open(IN, ${in}) || die "${in}: $!\n";
+  while (<IN>) {
+    chomp;
+    print "$_\n";
+
+  }
+  close(IN);
+}

--- a/CONTRIBUTIONS/md2html.sh
+++ b/CONTRIBUTIONS/md2html.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+### Convert all the MD files into HTML files
+for f in *.md
+do
+  html=`basename $f .md`.html
+  ./md2html.pl $f > $html
+done
+
+### Here please add [[#include "your-expected.md"]] to the line
+### index.html file so that you can include the expected MD file there.
+
+### Then include your expected MD files into the index.html file
+#./include.html index.html > index2.html
+
+### Here if there are any problems with the included results within the
+### "index2.html" file, please fix them manually.
+
+### After fixing all the problems within the "index2.html" file, please
+### rename it to "index.html".
+# mv index2.html index.html
+


### PR DESCRIPTION
I provided a Perl script to convert MD files into HTML files (=HTML fragments to be strict).

Now I'd like to provide another tool to include all the auto-generated HTML fragments into the main index.html file of the [WoT Use Cases and Requirements](https://w3c.github.io/wot-usecases/).

Note that you need to put `#include "your-expected.html"` on the line where you want to include the HTML fragment. Please see also the updated README.md within this PR for the detailed usage of the tools.