### PR TITLE
fix md2html.pl for respec

### DIFF
--- a/CONTRIBUTIONS/md2html.pl
+++ b/CONTRIBUTIONS/md2html.pl
@@ -7,6 +7,8 @@ my $section = "";
 my $section_id = "";
 my $is_list = 0;
 my $topic = "";
+my $current_level = 0;
+my $prev_level = 0;
 
 $src = $ARGV[0];
 $id = $src;
@@ -15,41 +17,51 @@ $id  =~ s/\.md$//;
 open(IN, ${src}) || die "${src}: $!\n";
 while (<IN>) {
   chomp;
+  s/</&lt;/g;
+  s/>/&gt;/g;
 
   while ($_ =~ /\[.*\]\(.*\)/g) {
-      $_ =~ s/\[(.*)\]\((.*)\)/<a href="$2">$1<\/a>/;
+    $_ =~ s/\[(.*)\]\((.*)\)/<a href="$2">$1<\/a>/;
   }
 
   if (/^## Title: (.*)$/) {
+    $current_level = 2;
     ${title} = $1;
-    print "<h3 id=\"${id}\">${title}</h3>\n";
+    print "<section id=\"${id}\">\n";
+    print "<h3>${title}</h3>\n";
 
   } elsif (/^### (.*)$/) {
-      ${section} = $1;
-      ${section} =~ s/:([\s]+|)$//;
+    $current_level = 3;
+    ${section} = $1;
+    ${section} =~ s/:([\s]+|)$//;
 
-      ${section_id} = $section;
-      ${section_id} =~ s/\(s\)//;
-      ${section_id} =~ tr/A-Z/a-z/;
+    ${section_id} = $section;
+    ${section_id} =~ s/\(s\)//;
+    ${section_id} =~ tr/A-Z/a-z/;
 
-      ${id} =~ tr/A-Z/a-z/;
+    ${id} =~ tr/A-Z/a-z/;
 
-      print "<h4 id=\"${id}-${section_id}\">${section}</h4>\n";
+    if ($prev_level >= $current_level) {
+      print "<\/section>\n\n";
+    }
+    print "<section id=\"${id}-${section_id}\">\n";
+    print "<h4>${section}</h4>\n";
+    $prev_level = $current_level;
 
   } elsif (/^(\-|\*) (.*)$/) {
-      ${topic} = $2;
-      if ($is_list eq 0) {
-        print "<ul>\n";
-      }
-      print "<li>${topic}</li>\n";
-      $is_list = 1;
+    ${topic} = $2;
+    if ($is_list eq 0) {
+      print "<ul>\n";
+    }
+    print "<li>${topic}</li>\n";
+    $is_list = 1;
 
   } else {
-      if ($is_list eq 1) {
-          print "</ul>\n";
-          $is_list = 0;
-      }
-      print "$_\n";
+    if ($is_list eq 1) {
+        print "</ul>\n";
+        $is_list = 0;
+    }
+    print "$_\n";
   }
 }
 close(IN);


### PR DESCRIPTION
Sorry but I've just remembered (1) we use ReSpec for spec generation and (2) ReSpec requires us some specific notation for section and heading, i.e., &lt;h2&gt; surrounded by &lt;section&gt; and &lt/section&gt;.

Note that we can use &lt;h3&gt;, &lt;h4&gt;, etc. instead of &lt;h2&gt; for human readability if we want.

Please see also the [Respec Editor's Guide](https://github.com/w3c/respec/wiki/ReSpec-Editor's-Guide#user-content-sections).