### PR TITLE
modify md2html to use dl

### DIFF
--- a/CONTRIBUTIONS/md2html.pl
+++ b/CONTRIBUTIONS/md2html.pl
@@ -19,6 +19,7 @@ while (<IN>) {
   chomp;
   s/</&lt;/g;
   s/>/&gt;/g;
+  s/\r$//;
 
   while ($_ =~ /\[.*\]\(.*\)/g) {
     $_ =~ s/\[(.*)\]\((.*)\)/<a href="$2">$1<\/a>/;
@@ -28,7 +29,9 @@ while (<IN>) {
     $current_level = 2;
     ${title} = $1;
     print "<section id=\"${id}\">\n";
-    print "<h3>${title}</h3>\n";
+    print "<h2>${title}</h2>\n";
+    print "<dl>\n";
+    $is_list = 0;
 
   } elsif (/^### (.*)$/) {
     $current_level = 3;
@@ -42,11 +45,16 @@ while (<IN>) {
     ${id} =~ tr/A-Z/a-z/;
 
     if ($prev_level >= $current_level) {
-      print "<\/section>\n\n";
+      print "<\/dd>\n";
     }
-    print "<section id=\"${id}-${section_id}\">\n";
-    print "<h4>${section}</h4>\n";
+    print "<dt>${section}</dt>\n";
+    print "<dd>\n";
     $prev_level = $current_level;
+    $is_list = 0;
+
+  } elsif (/^#### (.*)$/) {
+    print "<p>$_</p>\n";
+    $is_list = 0;
 
   } elsif (/^(\-|\*) (.*)$/) {
     ${topic} = $2;
@@ -57,11 +65,15 @@ while (<IN>) {
     $is_list = 1;
 
   } else {
-    if ($is_list eq 1) {
+    if (($is_list eq 1) && (/^$/)) {
         print "</ul>\n";
         $is_list = 0;
     }
     print "$_\n";
   }
 }
+
+print "<\/dd>\n";
+print "<\/dl>\n";
+print "<\/section>\n";
 close(IN);

--- a/index.html
+++ b/index.html
@@ -172,61 +172,57 @@
 		<h2>Use Cases</h2>
 		<section id="domains">
 	        <h2>Application Domains</h2>
-
-<section id="Retail">
+	        	           
+<!-- Categories of new use cases -->
 <section id="retail">
-<h3>Retail</h3>
+<h2>Retail</h2>
+<section id="retail">
+<h2>Retail</h2>
+<dl>
 
-<section id="retail-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 David Ezell, Michael Lagally, Michael McCool
 
-</section>
-
-<section id="retail-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
-<section id="retail-tracker issue id">
-<h4>Tracker Issue ID</h4>
 
-
-</section>
-
-<section id="retail-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="retail-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="retail-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="retail-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 Retailers, customers, suppliers.
 
-</section>
-
-<section id="retail-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 Integrating and interconnecting multiple devices into the common retail workflow 
 (i.e., transaction log) drastically improves retail business operations at multiple levels. 
@@ -236,33 +232,29 @@ that was not previously possible or viable in a meaningful way.
 It drastically speeds up the process of root cause analysis of operational issues and 
 simplifies the work of retailers.
 
-</section>
-
-<section id="retail-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Connected sensors, such as people counters, presence sensors, air quality, room ocupancy, door sensors. 
 Cloud services.  Video analytics edge services.
 
-</section>
-
-<section id="retail-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
  
 Inventory data, supply chain status information, discrete sensor data or data streams.
 
-</section>
-
-<section id="retail-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 &lt;List the affected WoT deliverables&gt;
 tbd
 
-</section>
-
-<section id="retail-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Falling costs of sensors, communications, and handling of very large volumes of data combined with cloud 
 computing enable retail business operations with increased operational efficiency, better customer service, 
@@ -276,20 +268,17 @@ Understanding of store activity juxtaposed with traditional information streams 
 comply better with work safety regulations, enhance system and site security, and improve worker efficiency 
 by providing real-time visibility into worker status, location, and work environment.
 
-</section>
-
-<section id="retail-variants">
-<h4>Variants</h4>
+</dd>
+<dt>Variants</dt>
+<dd>
 
 <ul>
 <li>Use edge computing, in particular video analytics, in combination with IoT devices to deliver an enhanced </li>
-</ul>
   customer experience, better manage inventory, or otherwise improve the store workflow.
   
-</section>
-
-<section id="retail-security considerations">
-<h4>Security Considerations</h4>
+</dd>
+<dt>Security Considerations</dt>
+<dd>
 
 <ul>
 <li>In retail, replay attacks can cause monetary loss, customers may be incorrectly charged or over-charged.</li>
@@ -304,10 +293,9 @@ by providing real-time visibility into worker status, location, and work environ
 <li>Make sure your network perimeter is defended with up to date firewall software.</li>
 </ul>
 
-</section>
-
-<section id="retail-privacy considerations">
-<h4>Privacy Considerations</h4>
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
  
 As a general rule, personal consumer information should not be stored.
 That is especially true in the retail industry where a security breach could cause financial, reputation, and brand damage.
@@ -317,33 +305,35 @@ WoT vendors and integrators should always have a privacy policy and make it easi
 By default, devices should adopt an opt-out policy.
 That means, unless the consumer explicitly allowed for the data capture and storage, avoid doing it.
 
-</section>
-
-<section id="retail-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT work items&gt;
 tbd
 
-</section>
-
-<section id="retail-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 &lt;Provide links to relevant standards that are relevant for this use case&gt;
 tbd
 
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="retail-comments">
-<h4>Comments</h4>
-
-
-</section>
-
-<section id="Audio_Video">
+<section id="audio_video">
+<h2>Audio/Video</h2>
 <section id="media-information-references">
-<h3>Media Use Case Information Bucket</h3>
+<h2>Media Use Case Information Bucket</h2>
+<dl>
 
 
 This document is not a full use case description. It is rather a collection of 
@@ -353,50 +343,44 @@ The intention is to trigger new ideas and collect them in a single document at t
 
 The document is work in progress.
 
-<section id="media-information-references-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 &lt;Put your name here&gt;
 
-</section>
-
-<section id="media-information-references-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
-
-<section id="media-information-references-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="media-information-references-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="media-information-references-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="media-information-references-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="media-information-references-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 &lt;List all stakeholders that are involved in the use case from the following list:
 <ul>
@@ -411,38 +395,33 @@ The document is work in progress.
 <li>directory service operator&gt;</li>
 </ul>
 
-</section>
-
-<section id="media-information-references-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 &lt;Provide a description of the problem that is solved by the use case and a reason why this use case is important for the users&gt;
 
-</section>
-
-<section id="media-information-references-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 &lt;List the target devices, e.g. as a sensor, solar panel, air conditioner&gt;
 
-</section>
-
-<section id="media-information-references-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 &lt;List the type of expected data, e.g. weather and climate data, medical conditions, machine sensors, vehicle data&gt;
 
-</section>
-
-<section id="media-information-references-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 &lt;List the affected WoT deliverables that have to be changed to enable this use case&gt;
 
-</section>
-
-<section id="media-information-references-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 <ul>
 <li>Sync of media across different devices:</li>
@@ -453,35 +432,32 @@ The document is work in progress.
 
 <ul>
 <li>Voice control of a media playback device (integration of smart speakers from multiple vendors)</li>
-</ul>
 Describe proprietary (vendor specific) device control interfaces to control media playback on TV set.
 (proprietary implementations exist, open protocol is proposed?)
+</ul>
 
-#### Variants:
+<p>#### Variants:</p>
 
 &lt;Describe possible use case variants, if applicable&gt;
 
-</section>
-
-<section id="media-information-references-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT standards and building blocks&gt;
 
-</section>
-
-<section id="media-information-references-existing standards & related information">
-<h4>Existing standards & related information</h4>
+</dd>
+<dt>Existing standards & related information</dt>
+<dd>
 
 &lt;Provide links to relevant standards that are relevant for this use case&gt;
 There are MANY TV standards and this would be a long list. Rather leave blank unless a very specific standard provides more insight.
 
-</section>
+</dd>
+<dt>Comments</dt>
+<dd>
 
-<section id="media-information-references-comments">
-<h4>Comments</h4>
-
-#### Further information and resources:
+<p>#### Further information and resources:</p>
 
 NHK Hybridcast updates:
 https://www.w3.org/2011/webtv/wiki/images/d/d1/MediaTimedEventsInHybridcast_TPAC20190916.pdf 
@@ -492,12 +468,16 @@ https://www.w3.org/2011/webtv/wiki/images/d/d1/MediaTimedEventsInHybridcast_TPAC
 BBC Moto GP at Home:
 https://2immerse.eu/motogp-at-home/  
 
+</dd>
+</dl>
+</section>
 <section id="nhk-device-tv-sync">
-<h3>Home WoT devices work according to TV programs</h3>
+<h2>Home WoT devices work according to TV programs</h2>
+<dl>
 
 
-<section id="nhk-device-tv-sync-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Hiroki Endo,
 Masaya Ikeo,
@@ -505,51 +485,44 @@ Shinya Abe,
 Hiroshi Fujisawa
 
 
-</section>
-
-<section id="nhk-device-tv-sync-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
-<section id="nhk-device-tv-sync-tracker issue id">
-<h4>Tracker Issue ID</h4>
 
-
-</section>
-
-<section id="nhk-device-tv-sync-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="nhk-device-tv-sync-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="nhk-device-tv-sync-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="nhk-device-tv-sync-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 Person watching TV, Broadcasters
 
-</section>
-
-<section id="nhk-device-tv-sync-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 &lt;Provide a description of the problem that is solved by the use case and a reason why this use case is important for the users&gt;
 
@@ -569,10 +542,9 @@ WoT devices work according to TV programs:
 <li>Smart Mirror is notified that favorite TV show will start.</li>
 </ul>
 
-</section>
-
-<section id="nhk-device-tv-sync-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 <ul>
 <li>Hybridcast TV</li>
@@ -582,25 +554,22 @@ WoT devices work according to TV programs:
 <li>Smart Mirror</li>
 </ul>
 
-</section>
-
-<section id="nhk-device-tv-sync-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 The trigger value of the scene of the TV program.
 Hybridcast connect application know the Thing Description of the devices in home. (Discovery?)
 
-</section>
-
-<section id="nhk-device-tv-sync-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 &lt;List the affected WoT deliverables&gt;
 
-</section>
-
-<section id="nhk-device-tv-sync-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Home smart devices behave according to TV programs.
 
@@ -611,118 +580,2013 @@ Hybridcast Contact application receives the information and controlls smart home
 
 !<a href="images/scenario_nhk.png">scenario_nhk</a>
 
-#### Variants:
+<p>#### Variants:</p>
 
 &lt;Describe possible use case variants, if applicable&gt;
 
-</section>
-
-<section id="nhk-device-tv-sync-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT work items&gt;
 
-</section>
-
-<section id="nhk-device-tv-sync-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 Hybridcast and Hybridcast Connect: a Japanese Integrated Broadcast-Broadband system, 
 HbbTV, 
 ATSC 3.0, 
 ...etc.
 
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="nhk-device-tv-sync-comments">
-<h4>Comments</h4>
+<section id="agriculture">
+<h2>Agriculture</h2>
+<section id="smart-agriculture">
+<h2>Smart Agriculture (Greenhouse Horticulture)</h2>
+<dl>
 
+<dt>Submitter(s)</dt>
+<dd>
 
+Ryuichi Matsukura, Takuki Kamiya
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+Agricultural corporation, Farmer, Manufacturers (Sensor, other facilities), Cloud provider
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Greenhouse Horticulture controlled by computers can create an optimal environment for growing plants. This enables to improve productivity and ensure stable vegetable production throughout the year, independent of the weather. This is the result of research on the growth of plants in the 1980s. For example, in tomatoes, switching to hydroponics and optimizing the temperature, humidity and CO2 concentration required for photosynthesis resulted in a five times increase in yield. The growth conditions for other vegetables also have been investigated, and this control system is applied now.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Sensors ( temperature, humidity, brightness, UV brightness, air pressure, and CO2)
+Heating, CO2 generator, open and close sunlight shielding sheet.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Sensors’ values to clarify the gaps between conditions for maximizing photosynthesis and the current environment.
+Following sensors values at one or some points in the greenhouse: temperature, humidity, brightness, and CO2.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+WoT Architecture、WoT Thing Description
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+Sensors and some facilities like heater, CO2 generator, sheet controller are connected to the gateway via wired or wireless networks. The gateway is connected to the cloud via the Internet. All sensors and facilities can be accessed and controlled from the cloud.
+To maximize photosynthesis, the temperature, CO2 concentration, and humidity in the greenhouse are mainly controlled. When the sunlight comes in the morning and CO2 concentration inside decreases, the application turns on the CO2 generator to keep over 400 ppm, the same as the air outside. The temperature in the greenhouse is adjusted by controlling the heater and the sunlight shielding sheet.
+The cloud gathers all sensor data and the status of the facilities. The application makes the best configuration for the region of the greenhouse located.
+
+<p>#### Variants:</p>
+
+&lt;Describe possible use case variants, if applicable&gt;
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+In the case of the wireless connection to the sensors, the gateway should keep the latest value of the sensors since the wireless connection is sometimes broken. The gateway can create a virtual entity corresponding to the sensor and allow the application to access this virtual entity having the actual sensor status like sleeping.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+</dd>
+<dt>Comments</dt>
+<dd>
+</dd>
+</dl>
 </section>
-<section id="Agriculture">
-#include="smart-agriculture.html"
 </section>
 
-<section id="Smarti_City">
-#include="smartcity-geolocation.html"
-#include="mmi-3-1_interactive-public-spaces.html"
-#include="mmi-3-2_meeting-room-event-assistance.html"
-</sectiion>
+<section id="smart-city">
+<h2>Smart City</h2>
+<section id="smartcity-geolocation">
+<h2>Smart City Geolocation</h2>
+<dl>
 
-<section id="Health">
-#include="smartcity-health-monitoring.html"
-#include="mmi-4-1_health-notifiers.html"
+<dt>Submitter(s)</dt>
+<dd>
+
+Jennifer Lin (GovTech Singapore), Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+Michael Lagally
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+A Smart City managing mobile devices and sensors,
+including passively mobile sensor packs, packages,
+vehicles, and autonomous robots, where their location needs to
+be determined dynamically.
+
+TODO: Stakeholders/Users need to be further clarified. They include "city government, people counting service providers, police, network providers, ...
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Smart Cities need to track a large number of mobile devices and sensors.
+Location information may be integrated with a logistics or fleet management
+system.
+A reusable geolocation module is needed with a common network interface to
+include in these various applications.
+For outdoor applications, GPS 
+could be used, but indoors other geolocation technologies might be 
+used, such as WiFi triangulation or vision-based navigation (SLAM).
+Therefore the geolocation information should be technology-agnostic.
+
+NOTE: we prefer the term "geolocation", even indoors, over "localization" to
+avoid confusion with language localization.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+One of the following:
+<ul>
+<li>A geolocation system on a personal device, such as a smart phone.</li>
+<li>A geolocation system to be attached to some other portable device.</li>
+<li>A geolocation system attached to a mobile vehicle.</li>
+<li>A geolocation system on a payload transported by a vehicle.</li>
+<li>A geolocation system on an indoor mobile robot.</li>
+</ul>
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+<ul>
+<li>Sensor ID</li>
+<li>Timestamp of last geolocation</li>
+<li>2D location</li>
+   * typically latitude and longitude
+   * May also be semantic, i.e. room in a building, exit
+</ul>
+
+Optional:
+<ul>
+<li>Semantic location</li>
+   * Possibly in addition to numerical lat/long location.
+<li>Altitude</li>
+   * May also be semantic, i.e. floor of a building
+<li>Heading</li>
+<li>Speed</li>
+<li>Accuracy information</li>
+   * Confidence interval, e.g. distance that true location will be within some probability.
+   * Gaussian covariance matrix
+   * For each measurement
+   * For lat/long, may be a single value (see web browser API; radius?)
+<li>Geolocation technology (GPS, SLAM, etc).  </li>
+   * Note that multiple technologies might be used together.
+   * Include parameters such as sample interval, accuracy
+<li>For each geolocation technology, data specific to that technology:</li>
+   * GPS: NMEA type
+<li>Historical data</li>
+</ul>
+
+Note: the system should be capable of notifying consumers
+of changes in location.
+This may be used to implement geofencing by some other system.  
+This may require additional parameters, such as the 
+maximum distance that the device may be moved before a notification is
+sent, or the maximum amount of time between updates.
+Notifications may be sent by a variety of means, some of which may
+not be traditional push mechanisms (for example, email might be used).
+For geofencing applications, it is not necessary that the device be aware
+of the fence boundaries; these can be managed by a separate system.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+node-wot
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+Smart Cities have the need to observe the physical locations of 
+large number of mobile devices 
+in use in the context of a Fleet or Logistics Management System, or
+to place sensor data on a map in a Dashboard application.
+These systems may also include geofencing notifications and mapping
+(visual tracking) capabilities.
+
+<p>#### Variants:</p>
+
+<ul>
+<li>A version of the system may log historical data so the past</li>
+  locations of the devices can be recovered.
+<li>Geolocation technologies other than GPS may be used.  The payload</li>
+  may contain additional information specific to the geolocation
+  technology used.  In particular, in indoor situations technologies such
+  as WiFi triangulation or (V)SLAM may be more appropriate.
+<li>Geofencing may be implemented using event notifications and</li>
+  will require setting of additional parameters such as maximum distance.
+</ul>
+
+</dd>
+<dt>Security Considerations</dt>
+<dd>
+
+High-resolution timestamps can be used in conjunction with cache manipulation to
+access protected regions of memory, as with the SPECTRE exploit. Certain
+geolocation APIs and technologies can return high-resolution timestamps which
+can be a potential problem.  Eventually these issues will be addressed in cache
+architecture but in the meantime a workaround is to artificially limit the 
+resolution of timestamps.
+
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
+
+Location is generally considered private information when it is used with a device
+that may be associated with a specific person, such as a phone or vehicle, as it
+can be used to track that person and infer their activities or who they associate 
+with (if multiple people are being tracked at once).  Therefore APIs to access geographic location
+in sensitive contexts are often restricted, and access is allowed only after confirming
+permission from the user.
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+There is no standardized semantic vocabulary for representing location data.
+Location data can be point data, a path, an area or a volumetric object.
+Location information can be expressed using multiple standards, 
+but the reader of location data in a TD or in data returned by an IoT device 
+must be able to unambiguously describe location information.
+
+There are both dynamic (data returned by a mobile sensor) and static (fixed installation
+location) applications for geolocation data.  For dynamic location data, some recommended vocabulary
+to annotate data schemas would be useful.  For static location data, a standard format
+for metadata to be included in a TD itself would be useful.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+<ul>
+<li>NMEA: defines sentences from GPS devices</li>
+<li>WGS84: https://en.wikipedia.org/wiki/World_Geodetic_System</li>
+   * World Geodetic System 
+   * Defines lat/long/alt coordinate system used by most other geolocation standards
+   * More complicated than you would think (need to deal with deviations of Earth from
+     a true sphere, gravitational irregularities, position of centroid, etc. etc.)
+<li>Basic Geo Vocabulary: https://www.w3.org/2003/01/geo/</li>
+   * Very basic RDF definitions for lat, long, and alt
+   * Does not define heading or speed
+   * Does not define accuracy
+   * Does not define timestamps
+   * Uses string as a data model (rather than a number)
+<li>W3C Geolocalization API: https://www.w3.org/TR/geolocation-API/</li>
+   * W3C Devices and Sensors WG is now handling
+   * There is an updated proposal: https://w3c.github.io/geolocation-sensor/#geolocationsensor-interface
+   * Data schema of updated proposal is similar to existing API, but all elements are now optional
+   * Data includes latitude, longitude, altitude, heading, and speed
+   * Accuracy is included for latitude/longitude (single number in meters, 95% confidence, interpretation
+     a little ambiguous, but probably intended to be a radius) and altitude, but not for heading or speed.
+<li>Open Geospatial Consortium: https://www.ogc.org/</li>
+   * See http://docs.opengeospatial.org/as/18-005r4/18-005r4.html
+      * Referring to locations by coordinates
+   * Has standards defining semantics for identifying locations
+   * Useful for mapping
+<li>ISO</li>
+   * ISO19111: https://www.iso.org/standard/74039.html
+      * Standard for referring to locations by coordinates
+      * Related to OGS standard above and WGS84
+   * Various other standards that relate to remote sensing, geolocation, etc.
+   * Here is an example (see references): https://www.iso.org/obp/ui/fr/#iso:std:iso:ts:19159:-2:ed-1:v1:en
+<li>SSN: https://www.w3.org/TR/vocab-ssn/</li>
+   * Defines "accuracy": https://www.w3.org/TR/vocab-ssn/#SSNSYSTEMAccuracy
+   * Definition of accuracy is consistent with how it is used in Web Geolocation API
+   * Also defines related terms Precision, Resolution, Latency, Drift, etc.
+<li>Timestamps:</li>
+   * W3C standard in proposed new web geolocation API: https://w3c.github.io/hr-time/#dom-domhighrestimestamp
+   * See also related issues such as latency defined in SSN
+</ul>
+
+Note that accuracy and time are issues that apply to all kinds of sensors, not just
+geolocation.  However, the specific geolocation technology of GPS 
+is special since it is also a source of accurate time.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+</dd>
+</dl>
 </section>
+<section id="mmi-3-1_interactive-public-spaces">
+<h2>Interactive Public Spaces</h2>
+<dl>
 
-<section id="Manufacturing">
-#include="big-data.html"
-</section>
-
-<section id="Multi_Vendor_System_Integration">
-#include="digital-twin.html"
-#include="X-Protocol-Interworking.html"
-</section>
-
-<section id="Multimodal_System_Integration">
-#include="mmi-5-1_multimodal-recognition-support.html"
-#include="mmi-5-2_enhancement-of-synergistic-interactions.html"
-</section>
-
-<section id="Accessibility">
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions">
-<h3>Audiovisual Devices Acting as Smartphone Extensions</h3>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Michael McCool
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-tracker issue id">
-<h4>Tracker Issue ID</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 Accessibility
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 &lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
 
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Public spaces provide many opportunities for engaging, social and fun interaction.
+At the same time,
+preserving privacy while sharing tasks and activities with other people is a major issue
+in ambient systems.
+These systems may also deliver personalized information in combination
+with more general services presented publicly.
+
+A trustful discovery of the services and devices available in such environments
+is a necessity to guarantee personalization and privacy in public-space applications.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Public spaces supporting personalizable services and device access.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Command and status information transferred between the personal mobile device
+application and the public space's services and devices.
+
+Profile data for user preferences.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+<ul>
+<li>WoT Thing Description</li>
+<li>WoT Discovery</li>
+<li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
+  in IoT orchestration services in the public space.
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+Interactive installations such as touch-sensitive or gesture-tracking billboards
+may be set up in public places.
+Objects that present public information (e.g. a map of a shopping mall)
+can use a multimodal interface (built-in or in tandem with the user's mobile devices)
+to simplify user interaction and provide faster access.
+Other setups can stimulate social activities,
+allowing multiple people to enter an interaction simultaneously to work together
+towards a certain goal (for a prize)
+or just for fun (e.g. play a musical instrument or control a lighting exhibition).
+In a context where privacy is an issue
+(for example, with targeted/personalized alerts or advertisements),
+the user's mobile device acts as a mediator for the services
+running on the public network.
+This allows the user to receive relevant information in the way she sees fit.
+Notifications can serve as triggers for interaction with public devices and services
+if the user chooses to do so.
+
+<p>#### Variants:</p>
+
+The user may have additional mobile devices they want to incorporate into
+an interaction, for example a headset acting as an auditory aid or personal speech output
+device.
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+Data format describing user interface preferences.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+This use case is based on MMI UC 3.1.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
+<section id="mmi-3-2_meeting-room-event-assistance">
+<h2>Meeting Room Event Assistance</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+Accessibility
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+&lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Meeting space supporting personalizable services and device access.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Command and status information transferred between the personal mobile device
+application and the meeting space's services and devices.
+
+Profile data for user preferences.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+<ul>
+<li>WoT Thing Description</li>
+<li>WoT Discovery</li>
+<li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
+  in IoT orchestration services in the meeting space.
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+A conference room where a series of meetings will take place.
+People can go in and out of the room before,
+after and during the meeting.
+The door is "touched" by a badge.
+An application on the user's mobile device can
+activate any available display in the room and the room and can access and
+receive notification from devices and services in the room.
+The chair of the meeting is notified by a dynamically composed graphic animation,
+audio notification or a mobile phone notification,
+about available devices and services, and 
+can install applications indicated by links.
+
+The chair of the meeting selects a setup procedure by text amongst the provided links.
+These options could be, for example:
+photo step-by-step instructions (smartphone, HDTV display, Web site),
+audio instructions (MP3 audio guide, room speakers reproduction, HDTV audio)
+or RFID enhanced instructions (mobile SmartTag Reader, RFID Reader for smartphone).
+The chair of the meeting chooses the room speakers reproduction,
+then the guiding Service is activated and he starts to set the video projector.
+After some attendees arrive,
+the chair of the meeting changes to the slide show option and continues to
+follow the instructions at the same step it was paused but with another more
+private modality for example, a smartphone slideshow.
+
+<p>#### Variants:</p>
+
+The user may have additional mobile devices they want to incorporate into
+an interaction, for example a headset acting as an auditory aid or personal speech output
+device.
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+Data format describing user interface preferences.
+
+Ability to install applications based on links that can access IoT services.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+This use case is based on MMI UC 3.2.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-motivation">
-<h4>Motivation</h4>
+<section id="health">
+<h2>Health</h2>
+
+<section id="public-health">
+<h2>Public Health</h2>
+<section id="smartcity-health-monitoring">
+<h2>Public Health Monitoring</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Jennifer Lin (GovTech Singapore)
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+Michael McCool, Michael Lagally
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+Agencies, companies and other organizations in a Smart City with 
+significant pedestrian traffic in a pandemic situation.
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+A system to monitor the health of people in public places is useful to
+control the spread of infectious diseases.  In particular, we would like
+to identify individuals with temperatures outside the norm (i.e. running
+a fever) and then take appropriate action.  Actions can include sending
+a notification or actuating a security device, such as a gate.
+
+This mechanism should be non-invasive and non-contact since the solution
+should not itself contribute to the spread of infectious diseases.
+
+Data may also be aggregated for statistics purposes, for example, to 
+identify the number of people in an area with elevated temperatures.
+This has additional requirements to avoid double-counting individuals.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+One of the following:
+<ul>
+<li>A thermal camera.</li>
+<li>Face detection (AI) service</li>
+     * May be on device or be an edge or cloud service.
+</ul>
+
+Optional:
+<ul>
+<li>RGB and/or depth camera registered with the thermal camera</li>
+<li>Cloud service for data aggregation and analytics.</li>
+<li>Some way to identify location (optional)</li>
+Note that location might be static and configured during installation,
+but might also be based on a localization technology if the device needs to be 
+portable (for example, if it needs to be set up quickly for an event).
+</ul>
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+<ul>
+<li>Sensor ID</li>
+<li>Timestamp</li>
+<li>Number of people identified with a fever in image</li>
+<li>Estimated temperature for each person</li>
+   * May be coarse, low/normal/high
+<li>Location</li>
+   * Latitude, Longitude, Altitude, Accuracy 
+   * Semantic (eg a particular building entrance)
+<li>Thermal image</li>
+</ul>
+
+Optional:
+<ul>
+<li>RGB image</li>
+<li>Depth image</li>
+<li>Localization technology (see localization use case)</li>
+<li>Integration with local IoT devices: gates, lights, or people (guards)</li>
+<li>Bounding boxes around faces of identified people in image(s)</li>
+<li>Data that can be used to uniquely identify a face (distinguish it from others)</li>
+    * Aggregation system may output the total number of unique faces with fever
+</ul>
+
+Note 1: the system should be capable of notifying consumers (such as security personnel),
+of fever detections.   
+This may be email, SMS, or some other mechanism, such as MQTT publication.
+
+Note 2: In all cases where images are captured, privacy considerations apply.
+
+It would also be useful to count unique individuals for statistics purposes,
+but not necessarily based on identifying particular people.  This is to
+avoid counting the same person multiple times.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+node-wot
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+A thermal camera image is taken of a group of people
+and an AI service is used to identify faces in the image.
+The temperature of each person is then estimated from the registered face;
+for greater accuracy, a consistent location for sampling should be used, such 
+as the forehead.
+The estimated temperature is compared to high (and optionally, low)
+thresholds and a notification (or other action) is taken if the 
+temperature is outside the norm.
+Additional features may be extracted to identify unique individuals.
+
+<p>#### Variants:</p>
+
+<ul>
+<li>Enough information is included in the notification that the specific</li>
+  person that raised the alarm can be identified.  For example, if an RGB
+  camera is also registered with the thermal camera, then a bounding box may
+  be indicated via JSON and the RGB image included; or the bounding box could
+  be actually drawn into the sent image, or the face could be cropped out.
+  This is useful if, for example, a notification needs to be sent to health
+  or security workers who need to identify the person in a crowd.
+<li>Instead of simply a notification, an action may be taken, such as closing</li>
+  or refusing to open a gate at the entrance to a building, to prevent sick
+  employees from entering the building.
+<li>To generate statistics, for example to count the number of people with</li>
+  fevers, then unique individuals need to be indentified to avoid counting
+  the same person more than once.
+<li>The same sensors might be used to determine the number of people in</li>
+  an area and send a notification if crowded conditions are detected, in
+  order to support social distancing behaviour (for instance, supporting
+  an app that notifies users when a destination is crowded) in a pandemic situation.
+<li>Cameras that provide video streams rather than still images.</li>
+</ul>
+
+</dd>
+<dt>Security Considerations</dt>
+<dd>
+
+<ul>
+<li>Because PII is involved (see below) access should be controlled (only provided to authorized users) and communications protected (encrypted).</li>
+</ul>
+
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
+
+<ul>
+<li>Images of people and their health status is involved.  </li>
+   - If later these are made public then the health information of a particular person would be released publically. 
+   - There is also the possibility that the camera data could be in error, and should be confirmed with a more accurate sensor.
+   - This information needs to be treated as PII and protected: only distributed to authorized users, and deleted when no longer needed.  
+   - However, derived aggregate information can be kept and published.
+</ul>
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+<ul>
+<li>Onboarding mechanism for rapidly deploying a large number of devices</li>
+<li>Standard vocabulary for geolocation information</li>
+<li>Implementations able to handle image payload formats, possibly in combination with non-image data (eg images and JSON in a single response)</li>
+<li>Video streaming support (if we wish to serve video stream from the camera instead of still images)</li>
+<li>Standard ways to specify notification mechanisms and data payloads for things like SMS and email (in addition to the expected MQTT, CoAP, and HTTP event mechanisms)</li>
+</ul>
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+<ul>
+<li>May be additional requirements for privacy since images of people and their health status is involved.</li>
+<li>Different sub-use cases: immediate alerts or actions vs. aggregate data gathering</li>
+</ul>
+
+</dd>
+</dl>
+</section>
+<section id="MedicalDevices">
+<h2>Machines in a hospital ICU should be able to speak to one another&lt;Pick a descriptive title&gt;</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Taki Kamiya
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+<ul>
+<li>device owners</li>
+<li>device user</li>
+<li>cloud provider</li>
+<li>service provider</li>
+<li>device manufacturer</li>
+<li>gateway manufacturer</li>
+<li>identity provider</li>
+</ul>
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Preventable medical errors may account for more than 100,000 deaths per year in U.S. alone. These errors are mainly caused by failures of communication such as a chart misread or the wrong data passed along to machines or staffs. Part of the problem could be solved if the machines could speak to one another.   Manufacturers have little incentive to make their proprietary code and data easily to accessible and process able by their competitors’ machines. So the task of middleman falls to the hospital staffs. In addition to saving lives, a common framework could result in collecting and recording more clinical data on patients, making it easier to deliver precision medicine.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+&lt;List the target devices, e.g. as a sensor, solar panel, air conditioner&gt;
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+&lt;List the type of expected data, e.g. weather and climate data, medical conditions, machine sensors, vehicle data&gt;
+
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
+
+&lt;List the affected WoT deliverables that have to be changed to enable this use case&gt;
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+Physiological Closed-Loop Control (PCLC) devices are a group of emerging technologies, which use feedback from physiological sensor(s) to autonomously manipulate physiological variable(s) through delivery of therapies conventionally delivered by clinician(s). 
+
+Clinical scenario without PCLC. An elderly female with end-stage renal failure was given a standard insulin infusion protocol to manage her blood glucose, but no glucose was provided. Her blood glucose dropped to 33, then rebounded to over 200 after glucose was given. This scenario has not changed for decades.
+
+The desired state with PCLC implemented in an ICU. A patient is receiving an IV insulin infusion and is having the blood glucose continuously monitored. The infusion pump rate is automatically adjusted according to the real-time blood glucose levels being measured, to maintain blood glucose values in a target range. If the patient’s glucose level does not respond appropriately to the changes in insulin administration, the clinical staff is alerted.
+
+Medical devices do not interact with each other autonomously (monitors, ventilator, IV pumps, etc.) Contextually rich data is difficult to acquire. Technologies and standards to reduce medical errors and improve efficiency have not been implemented in theater or at home.
+
+In recent years, researchers have made progress developing PCLC devices for mechanical ventilation, anesthetic delivery applications, and so on. Despite these promises and potential benefits, there has been limited success in the translation of PCLC devices from <a href="https://today.duke.edu/2014/07/benchbedside">bench to bedside</a>. A key challenge to bringing PCLC devices to a level required for a clinical trials in humans is risk management to ensure device reliability and safety.
+
+The United States Food and Drug Administration (FDA) classifies new hazards that might be introduced by PCLC devices into three categories. Besides clinical factors (e.g. sensor validity and reliability, inter- and intra-patient physiological variability) and usability/human factors (e.g. loss of situational awareness, errors, and lapses in operation), there are also engineering challenges including robustness, availability, and integration issues.
+
+<p>#### Variants:</p>
+
+US military developed ONR SBIR (Automated Critical Care System Prototype), and found those issues.
+
+<ul>
+<li>No plug and play, i.e. cannot swap O2 Sat with another manufacturer.</li>
+<li>No standardization of data outputs for devices to interoperate.</li>
+<li>Must have the exact make/model to replace a faulty device or system will not work.</li>
+</ul>
+
+</dd>
+<dt>Security Considerations</dt>
+<dd>
+
+Security considerations for interconnected and dynamically composable medical systems are critical not only because laws such as <a href="https://www.hhs.gov/hipaa/index.html">HIPAA</a> mandate it, but also because security attacks can have serious safety consequences for patients. The systems need to support automatic verification that the system components are being used as intended in the clinical context, that the components are authentic and authorized for use in that environment, that they have been approved by the hospital’s biomedical engineering staff and that they meet regulatory safety and effectiveness requirements.
+
+For security and safety reasons, <a href="#ICE">ICE (F2761-09)</a> medical devices never interact directly each other. All interaction is coordinated and controlled via the applications.
+
+While transport-level security such as TLS provides reasonable protection against external attackers, they do not provide mechanisms for granular access control for data streams happening within the same protected link. Transport-level security is also not sufficiently flexible to balance between security and performance. Another issue with widely used transport-level security solutions is the lack of support for multicast.
+
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
+
+&lt;Describe any issues related to privacy; if there are none, say "none" and justify&gt;
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+Multicast support. It has proven useful for efficient and scalable discovery and information exchange in industrial systems.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+<p>#### &lt;a name="ICE"&gt;&lt;/a&gt; <a href="https://www.astm.org/Standards/F2761.htm">F2761-09 (2013)</a> </p>
+
+Medical Devices and Medical Systems - Essential safety requirements for equipment comprising the patient-centric integrated clinical environment (ICE) - Part 1: General requirements and conceptual model.
+
+The idea behind ICE is to allow medical devices that conform to the ICE standard, either natively or using an adapter, to interoperate with other ICE-compliant devices regardless of manufacturer.
+
+<p>#### <a href="https://www.openice.info/">OpenICE</a></p>
+
+OpenICE is an initiative to create a community implementation of F2761-09 (ICE - Integrated Clinical Environment) based on <a href="https://www.omg.org/spec/DDS/About-DDS/">DDS</a>.
+
+<p>#### <a href="https://secwww.jhuapl.edu/mdira/documents">MDIRA Specification Document Version 1.0</a>. </p>
+
+MDIRA Version 1.0 provides requirements and implementation guidance for MDIRA-compliant systems focused on trauma and critical care in austere environments.
+
+Johns Hopkins University Applied Physics Laboratory (JHU-APL) lead a research project in collaboration with US military to develop a framework of autonomous / closed loop prototypes for military health care which are dual use for the civilian healthcare system.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+</dd>
+</dl>
+</section>
+</section>
+
+<section id="private-health">
+<h2>Private Health</h2>
+<section id="mmi-4-1_health-notifiers">
+<h2>Health Notifiers</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+Accessibility
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+&lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
+
+End user with a health problem they wish to monitor.
+
+Health services provider (doctor, nurse, paramedic, etc).
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+In critical situations regarding health,
+like a medical emergency,
+media multimodality may be the most effective way to communicate alerts,
+When the goal is to monitor the health evolution of a
+person in both emergency and non-emergency contexts,
+access via networked devices may be the most effective way to collect data and 
+monitor a patient's status.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Medical facilities supporting device and service access.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Command and status information transferred between the personal mobile device
+application and the meeting space's services and devices.
+
+Profile data for user preferences.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+<ul>
+<li>WoT Thing Description</li>
+<li>WoT Discovery</li>
+<li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
+  in IoT orchestration services.
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+In medical facilities,
+a system may provide multiple options to control sensor operations
+by voice or gesture ("start reading my blood pressure now").
+These interactions may be mediated by an application installed into a smartphone.
+The system integrates information from multiple sensors
+(for example, blood pressure and heart rate);
+reports medical sensor readings periodically (for example, to a remote medical facility)
+and sends alerts when unusual readings/events are detected.
+
+<p>#### Variants:</p>
+
+The user may have additional mobile devices they want to incorporate into
+an interaction, for example a headset acting as an auditory aid or personal speech output
+device.
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+Data format describing user interface preferences.
+
+Ability to install applications based on links that can access IoT services.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+This use case is based on MMI UC 3.2.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
+</section>
+</section>
+
+<section id="manufacturing">
+<h2>Manufacturing</h2>
+<section id="big-data">
+<h2>Big Data for Manufacturing</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael Lagally
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+Device owners, cloud provider.
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Production lines for industrial manufacturing consist of multiple machines, where each machine incorporates sensors for various values.
+A failure of a single machine can cause defective products or a stop of the entire production. 
+
+Big data analysis enables to identify behavioral patterns across multiple production lines of the entire production plant and across multiple plants.
+
+The results of this analysis can be used for optimizing consumption of raw materials, checking the status of production lines and plants and predicting and preventing fault conditions. 
+
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Various sensors, e.g. temperature, light, humidity, vibration, noise, air quality.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Discrete sensor values, such as temperature, light, humidity, vibration, noise, air quality readings.
+The data can be delivered periodically or on demand.
+ 
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+Thing Description: groups of devices, aggregation / composition mechanism, thing templates
+Discovery/Onboarding: Onboarding of groups of devices
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+A company owns multiple factories which contain multiple production lines.
+Examples are production lines, environment sensors, 
+These devices collect data from multiple sensors and transmit this information to the cloud. Sensor data is stored in the cloud, can be visualized and analyzed using machine learning / AI.
+ 
+The cloud service allows to manage single and groups of devices.
+Combining the data streams from multiple devices allows to get an easy overview of the state of all connected devices in the user's realm.
+ 
+In many cases there are groups of devices of the same kind, so the aggregation of data across devices can serve to identify anomalies or to predict impending outages.
+
+The cloud service allows to manage single and groups of devices and can help to identify abonormal conditions.
+For this purpose a set of rules can be defined by the user, which raises alerts towards the user or triggers actions on devices based on these rules.
+
+This enables the early detection of pending problems and reduces the risk of machine outages, quality problems or threats to the environment or life of humans.
+
+<p>#### Variants:</p>
+
+&lt;Describe possible use case variants, if applicable&gt;
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+&lt;Describe any gaps that are not addressed in the current WoT work items&gt;
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+&lt;Provide links to relevant standards that are relevant for this use case&gt;
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+See also Digital Twin use case.
+
+
+</dd>
+</dl>
+</section>
+</section>
+
+<section id="multi-vendor">
+<h2>Multi-Vendor System Integration</h2>
+<section id="wot-profile">
+<h2>Out of the box interoperability</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael Lagally
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+All WoT members, specifically Sebastian Kaebisch, Michael McCool, Ege Korkan, Zoltan Kis, Takuki Kamiya, Ryuichi Matsukura, Kunihiko Toumura, Michael Koster.
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+<ul>
+<li>device owner</li>
+<li>service provider</li>
+<li>cloud provider</li>
+<li>device manufacturer</li>
+<li>gateway manufacturer</li>
+</ul>
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+<ul>
+<li>As an device owner, I want to know whether a device will work with my system before I purchase it to avoid wasting money.</li>
+    - Installers of IoT devices want to be able to determine if a given device will be compatible with the rest of their installed systems and whether they will have access to its data and affordances.
+</ul>
+
+<ul>
+<li>As a developer, I want TDs to be as simple as possible so that I can efficiently develop them.</li>
+   - Here "simple" should relate to the end goal, "efficiently develop"; that is, TDs should be straightforward for the average developer to complete and validate.
+</ul>
+
+<ul>
+<li>As a developer, I want to be able to validate that a Thing will be compatible with a Consumer without having to test against every possible consumer.</li>
+</ul>
+
+<ul>
+<li>As a cloud provider I want to onboard, manage and communicate with as many devices as possible out of the box.</li>
+This should be possible without device specific customization.
+</ul>
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+sensors, actuators, gateways, cloud, directory service.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+discrete or streaming data.
+
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
+
+WoT Profile, WoT Thing Description
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+As a consumer of devices I want to be able to process data from any device that conforms to a class of devices.
+
+I want to have a guarantee that I'm able to correctly interact with all affordances of the Thing that complies with this class of devices.
+Behavioral ambiguities between different implementations of the same description should not be possible. 
+
+I want to integrate it into my existing scenarios out of the box, i.e. with close to zero configuration tasks.
+
+<p>#### Variants:</p>
+
+N/A
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+&lt;Describe any gaps that are not addressed in the current WoT standards and building blocks&gt;
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+various.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+A strawman proposal for a profile specification has been submitted at: https://github.com/w3c/wot-profile
+
+An initial set of requirements is available here:
+https://github.com/w3c/wot-profile/edit/master/REQUIREMENTS/requirements.md
+
+
+Recommendations for commonalities and interoperability profiles of IoT platforms: 
+https://european-iot-pilots.eu/wp-content/uploads/2018/11/D06_02_WP06_H2020_CREATE-IoT_Final.pdf
+</dd>
+</dl>
+</section>
+<section id="digital-twin">
+<h2>Digital Twin</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael Lagally
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+Device owners, cloud provider.
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+A digital twin is the virtual representation of a physical asset such as a machine, a vehicle, robot, sensor. 
+Using a digital twin allows businesses to analyze their physical assets to troubleshoot in real time, predict future problems, minimize downtime, and perform simulations to create new business opportunities.
+
+A digital twin may also be called a twin or a shadow. Digital twin technology may be referred to as device virtualization.
+
+Digital twins can be located in the edge or in the cloud.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Various devices such as sensors, machines, vehicles, production lines, industry robots.
+
+Digital twin platforms at the edge or in the cloud.
+
+&lt;List the target devices, e.g. as a sensor, solar panel, air conditioner&gt;
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+ 
+&lt;List the type of expected data, e.g. weather and climate data, medical conditions, machine sensors, vehicle data&gt;
+
+Machine status information, discrete sensor data or data streams.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+&lt;List the affected WoT deliverables&gt;
+<ul>
+<li>WoT Architecture  </li>
+<li>WoT Thing Description  </li>
+<li>WoT Profile  </li>
+<li>WoT Scripting?  </li>
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+&lt;Provide a description from the users perspective&gt;
+
+The user benefits from using digital twins with the following scenarios:
+
+<ul>
+<li>Better visibility: Continually view the operations of the machines or devices, and the status of their interconnected systems.</li>
+</ul>
+
+<ul>
+<li>Accurate prediction: Retrieve the future state of the machines from the digital twin model by using modeling.</li>
+</ul>
+
+<ul>
+<li>What-if analysis: Easily interact with the model to simulate unique machine conditions and perform what-if analysis using well-designed interfaces.</li>
+</ul>
+
+<ul>
+<li>Documentation and communication: Use of the digital twin model helps to understand, document, and explain the behavior of a specific machine or a collection of machines.</li>
+</ul>
+
+<ul>
+<li>Integration of disparate systems: Connect with back-end applications related to supply chain operations such as manufacturing, procurement, warehousing, transportation, or logistics.</li>
+</ul>
+
+
+</dd>
+<dt>Variants</dt>
+<dd>
+
+<p>#### Virtual Twin</p>
+
+The virtual twin is a representation of a physical device or an asset. A virtual twin uses a model that contains observed and desired attribute values and also uses a semantic model of the behavior of the device.
+
+Intermittent connectivity: An application may not be able to connect to the physical asset. In such a scenario, the application must be able to retrieve the last known status and to control the operation states of other assets.
+
+Protocol abstraction: Typically, devices use a variety of protocols and methods to connect to the IoT network. From a users perspective this complexity should not affect other business applications such as an enterprise resource planning (ERP) application. 
+
+Business rules: The user can specify the normal operating range of a property in a semantic model. 
+Business rules can be declaratively defined and actions can be automatically invoked in the edge or on the device.
+
+Example: In a fleet of connected vehicles, the user monitors a collection of operating parameters, such as fuel level, location, speed and others. The semantics-based virtual twin model enables the user to decide whether the operating parameters are in normal range. In out of range conditions the user can take appropriate actions.
+
+
+<p>#### Predictive Twin</p>
+
+In a predictive twin, the digital twin implementation builds an analytical or statistical model for prediction by using a machine-learning technique. It need not involve the original designers of the machine. It is different from the physics-based models that are static, complex, do not adapt to a constantly changing environment, and can be created only by the original designers of the machine.
+
+A data analyst can easily create a model based on external observation of a machine and can develop multiple models based on the user’s needs.
+The model considers the entire business scenario and generates contextual data for analysis and prediction.
+
+When the model detects a future problem or a future state of a machine, the user can prevent or prepare for them.
+The user can use the predictive twin model to determine trends and patterns from the contextual machine data. The model helps to address business problems.
+
+
+<p>#### Twin Projections</p>
+
+In twin projections, the predictions and the insights integrate with back-end business applications, making IoT an integral part of business processes.
+When projections are integrated with a business process, they can trigger a remedial business workflow.
+
+Prediction data offers insights into the operations of machines. Projecting these insights into the back-end applications infrastructure enables business applications to interact with the IoT system and transform into intelligent systems.
+
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+&lt;Describe any gaps that are not addressed in the current WoT work items&gt;
+WoT does not define a way to describe the behavior of a thing to use for a simulation.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+&lt;Provide links to relevant standards that are relevant for this use case&gt;
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
+<section id="X-Protocol-Interworking">
+<h2>Cross Protocol Interworking</h2>
+<dl>
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael Lagally
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+Ege Korkan, Michael McCool, Michael Koster, Sebastian Käbisch
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+Device owners, cloud providers.
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+In smart city, home and industrial scenarios various devices are connected to a common network. These devices implement different protocols. To enable interoperability, an "agent" needs to communicate across different protocols. Platforms for this agent can be edge devices, gateways or cloud services.
+
+Interoperability across protocols is a must for all user scenarios that integrate devices from more than one protocol.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Various sensors, e.g. temperature, light, humidity, vibration, noise, air quality, edge devices, gateways, cloud servers and services.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Discrete sensor values, such as temperature, light, humidity, vibration, noise, air quality readings.
+A/V streams.
+The data can be delivered periodically or on demand.
+ 
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+WoT Profiles.
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+There are multiple user scenarios that are addressed by this use case. 
+
+An example in the smart home environment is an automatic control lamps, air conditioners, heating, window blinds in a household 
+based on sensor data, e.g. sunlight, human presence, calendar and clock, etc.
+
+In an industrial environment individual actuators and production devices use different protocols. 
+Examples include MQTT, OPC-UA, Modbus, Fieldbus, and others.
+Gathering data from these devices, e.g. to support digital twins or big data use cases requires an "Agent" to bridge across these protocols.
+To provide interoperability and to reduce implementation complexity of this agent a common set of (minimum and maximum) 
+requirements need to be supported by all interoperating devices. 
+
+A smart city environment is similar to the industrial scenario in terms of device interoperability. Devices differ however, 
+they include smart traffic lights, traffic monitoring, people counters, cameras.
+
+<p>#### Variants:</p>
+
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+A common profile across protocols is required to address this use case. 
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+MQTT, OPC-UA, BACNet, CoAP, various other home and industrial protocols.
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
+</section>
+
+<section id="multimodal">
+<h2>Multimodal System Integration</h2>
+<section id="mmi-5-1_multimodal-recognition-support">
+<h2>Multimodal Recognition Support</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+Accessibility
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+&lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+Recognizer system development has arrived at a point of maturity where
+if we want to dramatically enhance recognition performance,
+sensor fusion from multiple modalities is needed.
+In order to achieve this,
+an image recognizer should incorporate results coming from other 
+kinds of recognizers (e.g. audio recognizer) within the network
+engaged in the same interaction cycle.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+Audio sensing device (microphone).
+
+Video sensing device (camera).
+
+Audio recognition service.
+
+Video recognition service.
+
+Devices capabale of presenting alerts in various modalities.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Command and status information transferred between the sensing devices,
+the recognition services, and the alert devices.
+
+Profile data for user preferences.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+<ul>
+<li>WoT Thing Description</li>
+<li>WoT Discovery</li>
+<li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
+  in IoT orchestration services.
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+An audio recognizer has been trained with the more common sounds in the house,
+in order to provide alerts in case of an emergency.
+In the same house a security system uses a video recognizer to identify people
+at the front door.
+These two systems need to cooperate with a remote home management system
+to provide integrated services.
+
+<p>#### Variants:</p>
+
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+Support for video and audio recognition services.
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+This use case is based on MMI UC 5.1.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
+<section id="mmi-5-2_enhancement-of-synergistic-interactions">
+<h2>Enhancement of Synergistic Interactions</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+Accessibility
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+&lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
+
+</dd>
+<dt>Motivation</dt>
+<dd>
+
+One of the main indicators concerning the usability of a system
+is the corresponding level of accessibility provided by it.
+The opportunity for all the users to receive and to deliver all kinds of information,
+regardless of the information format or the type of user profile,
+state or impairment is a recurrent need in web applications.
+One of the means to achieve accessibility is the design of a more
+synergic interaction based on the discovery of multimodal Modality Components.
+
+Synergy is two or more entities functioning together to produce a result
+that is not obtainable independently.
+It means "working together".
+For example,
+how to avoid disruptive interactions 
+in nomadic systems (always affected by the changing context) 
+is an important issue.
+In these applications,
+user interaction is difficult,
+distracted and less precise.
+Discovery and use of alternative input and output devices
+can increase synergic interaction offering new possibilities 
+more adapted to the current context.
+Such a system can also enhance the fusion process for target groups of 
+users experiencing permanent or temporary learning difficulties or with sensorial,
+emotional or social impairments.
+
+</dd>
+<dt>Expected Devices</dt>
+<dd>
+
+A normal client computer with I/O devices that need to be emulated.
+
+Alternative I/O devices that need to be interfaced to the client system.
+
+</dd>
+<dt>Expected Data</dt>
+<dd>
+
+Command and status information transferred between the client computer
+and the alternative I/O devices.
+
+Profile data for user preferences.
+
+</dd>
+<dt>Dependencies</dt>
+<dd>
+
+<ul>
+<li>WoT Thing Description</li>
+<li>WoT Discovery</li>
+<li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
+  in IoT orchestration services.
+</ul>
+
+</dd>
+<dt>Description</dt>
+<dd>
+
+A person working mostly with a PC is having a problem with his right arm and hands.
+He is unable to use a mouse or a keyboard for a few months.
+He can point at things, sketch, clap, make gestures, but he can not make any precise movements.
+A generic interface allows this person to perform his most important tasks in his
+personal devices:
+to call someone, open a mailbox, access his agenda or navigate over some Web pages.
+The generic interface can propose child-oriented intuitive interfaces like a
+clapping-based interface,
+a very articulated TTS component, or reduced gesture input widgets.
+Other specialized devices might include phones with very big numbers,
+very simple remote controls,
+screens displaying text at high resolution,
+or voice command devices.
+
+<p>#### Variants:</p>
+
+
+</dd>
+<dt>Gaps</dt>
+<dd>
+
+
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+This use case is based on MMI UC 5.2.
+
+</dd>
+<dt>Comments</dt>
+<dd>
+
+Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
+</section>
+
+<section id="accessibility">
+<h2>Accessibility</h2>
+<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions">
+<h2>Audiovisual Devices Acting as Smartphone Extensions</h2>
+<dl>
+
+<dt>Submitter(s)</dt>
+<dd>
+
+Michael McCool
+
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
+
+&lt;Suggest reviewers&gt;
+
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Category</dt>
+<dd>
+
+Accessibility
+
+</dd>
+<dt>Class</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+&lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
+
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 Many of today's home IoT-enabled devices can provide similar functionality
 (e.g. audio/video playback),
@@ -742,10 +2606,9 @@ context of use.
 Both aspects provide arguments for exploring use cases where
 applications use distributed multimodal interfaces.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Mobile phone or other client running an application requiring a extended and
 more accessible user interface.
@@ -757,10 +2620,9 @@ application.
 Possible edge computation services providing speech-to-text or described video
 (e.g. object detection) capabilities.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Visual display information mapping information from audio to visual modalities,
 for example text generated from voice recognition.
@@ -773,22 +2635,20 @@ to visual icons.
 Visual information mapped to audio information, for example,
 described video based on an AI service providing object recognition.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 <ul>
 <li>WoT Thing Description</li>
 <li>WoT Discovery</li>
 <li>Optional: WoT Scripting API accessible from application for interacting</li>
-</ul>
 with devices.
+</ul>
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 A home entertainment system is adapted by a mobile device
 as a set of user interface components.
@@ -820,89 +2680,83 @@ it is carried over to another screen when she switches rooms,
 or replaced with a different modality such as voice 
 if there are no displays in the new location.
 
-#### Variants:
+<p>#### Variants:</p>
 
 Modalities may be translated from one form to another to accomodate
 accessibility issues, for example, visual cues into audio cues and 
 vice-versa, as appropriate.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 An AI service may be require to perform modality mapping, for example,
 object recognition.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 This use case is based on MMI UC 1.1.
 
-</section>
-
-<section id="mmi-1-1_audiovisual-devices-as-smartphone-extensions-comments">
-<h4>Comments</h4>
+</dd>
+<dt>Comments</dt>
+<dd>
 
 Does not include Requirements section from original MMI use case.
 Variant supporting 
 modality conversion is not included in the original MMI use case.
+</dd>
+</dl>
+</section>
 <section id="mmi-1-2_unified-smart-home-control-and-status">
-<h3>Unified Smart Home Control and Status Interface</h3>
+<h2>Unified Smart Home Control and Status Interface</h2>
+<dl>
 
-<section id="mmi-1-2_unified-smart-home-control-and-status-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Michael McCool
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-tracker issue id">
-<h4>Tracker Issue ID</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 Accessibility
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="mmi-1-2_unified-smart-home-control-and-status-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 &lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 The increase in the number of controllable devices in an
 intelligent home creates a problem with controlling all available services
@@ -915,10 +2769,9 @@ In addition,
 multiple input mechanisms could be selected by the user based on device type,
 level of trust and the type of interaction required for a particular task.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Mobile phone or other client running an application providing command
 mediation capabilities.
@@ -926,30 +2779,27 @@ mediation capabilities.
 IoT-enabled smart home devices supporting
 remote sensing and actuation functionality.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Command and status information transferred between the command mediation
 application and one or more devices.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 <ul>
 <li>WoT Thing Description</li>
 <li>WoT Discovery</li>
 <li>Optional: WoT Scripting API accessible from application for interacting </li>
-</ul>
   with devices.
+</ul>
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Smart home functionality (window blinds, lights, air conditioning etc.)
 is controlled through a multimodal interface,
@@ -968,89 +2818,84 @@ as workout intensity recorded by the fitness equipment increases.
 The same data can also increase or decrease volume and tempo of music tracks
 played by the user's mobile device or the home's media system.
 
-#### Variants:
+<p>#### Variants:</p>
 
 The intelligent home in tandem with the user's personal
 devices can additionally monitor user behavior for emotional patterns
 such as 'tired' or 'busy' and adapt further.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 A service may be needed to recognize gestures and emotional states.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 This use case is based on MMI UC 1.2; original title was Intelligent Home Apparatus.
 
-</section>
-
-<section id="mmi-1-2_unified-smart-home-control-and-status-comments">
-<h4>Comments</h4>
+</dd>
+<dt>Comments</dt>
+<dd>
 
 Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="Automotive">
+<section id="automotive">
+<h2>Automotive</h2>
 <section id="mmi-2-1_smart-car-configuration-management">
-<h3>Smart Car Configuration Management</h3>
+<h2>Smart Car Configuration Management</h2>
+<dl>
 
-<section id="mmi-2-1_smart-car-configuration-management-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Michael McCool
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-tracker issue id">
-<h4>Tracker Issue ID</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 Accessibility
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="mmi-2-1_smart-car-configuration-management-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 &lt;List all users that are involved in the use case, e.g. device manufacturer, gateway manufacturer, cloud provider&gt;
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 User interface personalization is a task that most often needs to be repeated
 for all Devices a user wishes to interact with recurringly.
@@ -1063,10 +2908,9 @@ A standardized set of personal information and preferences that could be used
 to configure personalizable devices automatically would be very helpful for all
 these cases in which the interaction becomes a customary practice.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Personal mobile device running an application providing command
 mediation capabilities.
@@ -1074,32 +2918,29 @@ mediation capabilities.
 IoT-enabled smart car supporting
 remote sensing, actuation, and configuration functionality.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Command and status information transferred between the personal mobile device
 application and the car's services and devices.
 
 Profile data for user preferences.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 <ul>
 <li>WoT Thing Description</li>
 <li>WoT Discovery</li>
 <li>Optional: WoT Scripting API in application on mobile personal device and possibly</li>
-</ul>
   in IoT orchestration services in the car.
+</ul>
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Basic in-car functionality is standardized to be managed by other devices.
 A user can control seat, radio or AC settings through a personalized multimodal interface
@@ -1124,133 +2965,124 @@ for example to manage playback of music tracks through the car's voice control s
 Sensor data provided by the phone can be mixed with data recorded by the car's own sensors
 to profile user behavior which can be used as context in multimodal interaction.
 
-#### Variants:
+<p>#### Variants:</p>
 
 Additional portable devices may be brought into the car and also be
 incorporated into an application, for example, a GPS navigation system.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 Data format describing user interface preferences.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 This use case is based on MMI UC 2.1.
 
-</section>
-
-<section id="mmi-2-1_smart-car-configuration-management-comments">
-<h4>Comments</h4>
+</dd>
+<dt>Comments</dt>
+<dd>
 
 Does not include Requirements section from original MMI use case.
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="Energy_Smart_Grid">
+<section id="smart-grids">
+<h2>Energy / Smart Grids</h2>
 <section id="smart-grid">
-<h3>Smart Grids</h3>
+<h2>Smart Grids</h2>
+<dl>
 
-<section id="smart-grid-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Christian Glomb (Siemens)
 
-</section>
-
-<section id="smart-grid-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 Michael Lagally (Oracle)
 
-</section>
-
-<section id="smart-grid-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="smart-grid-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="smart-grid-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="smart-grid-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="smart-grid-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 <ul>
-<li>Grid operators on all voltage levels line Distribution System Operators (DSO), Transmission System Operators (TSO)</li>
-<li>Plant operators (centralized as well as de-centralized producers)</li>
-<li>Virtual Power Plant (VPP) operators</li>
-<li>Energy grid markets</li>
-<li>Cloud providers where grid backend services are hosted and where Operation Technology bridges to Information Technology</li>
-<li>Device manufacturers, owners, and users; devices include communication gateways, monitoring and control units</li>
+<li>Grid operators on all voltage levels line Distribution System Operators (DSO), Transmission System Operators (TSO)</li>
+<li>Plant operators (centralized as well as de-centralized producers)</li>
+<li>Virtual Power Plant (VPP) operators</li>
+<li>Energy grid markets</li>
+<li>Cloud providers where grid backend services are hosted and where Operation Technology bridges to Information Technology</li>
+<li>Device manufacturers, owners, and users; devices include communication gateways, monitoring and control units</li>
 </ul>
 
-</section>
-
-<section id="smart-grid-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 &lt;Provide a description of the problem that is solved by the use case and a reason why this use case is important for the users&gt;
 
-</section>
-
-<section id="smart-grid-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 A smart grid integrates all players in the electricity market into one overall system through the interaction of generation, storage, grid management and consumption. Power and storage plants are already controlled today in such a way that only as much electricity is produced as is needed. Smart grids include consumers as well as small, decentralized energy suppliers and storage locations in this control system, so that on the one hand, consumption is more homogeneous in terms of time and space (see also intelligent electricity consumption) and on the other hand, in principle inhomogeneous producers (e.g. wind power) and consumers (e.g. lighting) can be better integrated.
 
-</section>
-
-<section id="smart-grid-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 <ul>
-<li>Weather and climate data</li>
-<li>Metering data (both production as well as consumption as well as storage, e.g. 15 min. intervals)</li>
-<li>Real time data from PMUs (Phasor Measurement Units)</li>
-<li>Machine and equipment monitoring data (enabling health checks)</li>
-<li>...</li>
+<li>Weather and climate data</li>
+<li>Metering data (both production as well as consumption as well as storage, e.g. 15 min. intervals)</li>
+<li>Real time data from PMUs (Phasor Measurement Units)</li>
+<li>Machine and equipment monitoring data (enabling health checks)</li>
+<li>...</li>
 </ul>
 
-</section>
-
-<section id="smart-grid-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 WoT Architecture, WoT Binding Templates (covering protocol specifica)
 
-</section>
-
-<section id="smart-grid-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 The term Smart Grid refers to the communicative networking and control of power generators, storage facilities, electrical consumers, and grid equipment in power transmission and distribution networks for electricity supply. This enables the optimization and monitoring of the interconnected components. The aim is to secure the energy supply on the basis of efficient and reliable system operation.
 
-#### Variants:
+<p>#### Variants:</p>
 
 ##### Decentralized Power Generation
 While electricity grids with centralized power generation have dominated up to now, the trend is moving towards decentralized generation plants, both for generation from fossil primary energy through small CHP plants and for generation from renewable sources such as photovoltaic systems, solar thermal power plants, wind turbines and biogas plants. This leads to a much more complex structure, primarily in the area of load control, voltage maintenance in the distribution grid and maintenance of grid stability. In contrast to medium to large power plants, smaller, decentralised generation plants also feed directly into the lower voltage levels such as the low-voltage grid or the medium-voltage grid. This use case variants also includes operation and control of energy storages like batteries.
@@ -1265,109 +3097,102 @@ For consumers, a major change is the installation of smart meters. Their core ta
 ##### Other variants
 Emergency response, grid synchronization, grid black start
 
-</section>
-
-<section id="smart-grid-building blocks">
-<h4>Building Blocks</h4>
+</dd>
+<dt>Building Blocks</dt>
+<dd>
 <ul>
-<li>Multi-Stakeholder Operation: Multiple involved parties have to find a common mode of operation</li>
-<li>Device Lifecycle Management: Since the VPP is a dynamic system of loosely coupled DERs, the appearance and disappearance of DERs as well as the software management on the devices itself requires a means to orchestrate the lifecycle of individual device's respective components.</li>
-<li>Embedded Runtime: Especially for DERs in remote locations, maintaining a close couple control loop can be expensive if feasible at all. Therefore, it is desirable to be able to offload control logic to the DER itself.</li>
-<li>Ensemble Discovery: In order to dynamically find matching DERs needed for the operational goal of a VPP, a registry with different options of DER discovery is needed.</li>
-<li>Content-Negotiation: The different stakeholders have to interact and therefore need a common data format.</li>
-<li>Resource Description: The DER has to describe itself to enable discovery of single DERs and ensembles, also the operational data needs to be understood by the different stakeholders without engineering effort.</li>
-<li>Push Services: As there is a fan-out with many devices that probably have a rate-limited connection connecting to one single command centre, a bidirectional communication mechanism is needed rather than polling for the reverse direction</li>
-<li>Object Memory: As multiple and interchangable stakeholders are involved in the application, a backlog of the object is beneficial for scrollkeeping</li>
+<li>Multi-Stakeholder Operation: Multiple involved parties have to find a common mode of operation</li>
+<li>Device Lifecycle Management: Since the VPP is a dynamic system of loosely coupled DERs, the appearance and disappearance of DERs as well as the software management on the devices itself requires a means to orchestrate the lifecycle of individual device's respective components.</li>
+<li>Embedded Runtime: Especially for DERs in remote locations, maintaining a close couple control loop can be expensive if feasible at all. Therefore, it is desirable to be able to offload control logic to the DER itself.</li>
+<li>Ensemble Discovery: In order to dynamically find matching DERs needed for the operational goal of a VPP, a registry with different options of DER discovery is needed.</li>
+<li>Content-Negotiation: The different stakeholders have to interact and therefore need a common data format.</li>
+<li>Resource Description: The DER has to describe itself to enable discovery of single DERs and ensembles, also the operational data needs to be understood by the different stakeholders without engineering effort.</li>
+<li>Push Services: As there is a fan-out with many devices that probably have a rate-limited connection connecting to one single command centre, a bidirectional communication mechanism is needed rather than polling for the reverse direction</li>
+<li>Object Memory: As multiple and interchangable stakeholders are involved in the application, a backlog of the object is beneficial for scrollkeeping</li>
 </ul>
 
-</section>
-
-<section id="smart-grid-non-functionals">
-<h4>Non-Functionals</h4>
+</dd>
+<dt>Non-Functionals</dt>
+<dd>
 <ul>
-<li>Privacy: As fine-grained metering informtion provides sensitive data about a household, the system should show a high digree of privacy</li>
-<li>Trust: Since the data exchange between the virtual power plant and the distributed energy resource leads to a physical action that invokes high currents and monetary flows, the integrity of both parties and the exchange's data is crucial</li>
-<li>Layered L7 Communication: Since multiple different links are used for monitoring and control, integration requires a clear and consistent seperation of information from the used serialization and application protocols to enable the exchange of homogenous information over heterogenous application layer protocols</li>
+<li>Privacy: As fine-grained metering informtion provides sensitive data about a household, the system should show a high digree of privacy</li>
+<li>Trust: Since the data exchange between the virtual power plant and the distributed energy resource leads to a physical action that invokes high currents and monetary flows, the integrity of both parties and the exchange's data is crucial</li>
+<li>Layered L7 Communication: Since multiple different links are used for monitoring and control, integration requires a clear and consistent seperation of information from the used serialization and application protocols to enable the exchange of homogenous information over heterogenous application layer protocols</li>
 </ul>
 
-</section>
-
-<section id="smart-grid-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT standards and building blocks&gt;
 
-</section>
-
-<section id="smart-grid-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 IEC 61850 - International standard for data models and communication protocols
 
 IEEE 1547 - US standard for interconnecting distributed resources with electric power systems
 
+</dd>
+<dt>Comments</dt>
+<dd>
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="smart-grid-comments">
-<h4>Comments</h4>
-</section>
-
-<section id="Transportation">
 <section id="transportation">
-<h3>Transportation</h3>
+<h2>Transportation</h2>
+<section id="transportation">
+<h2>Transportation</h2>
+<dl>
 
-<section id="transportation-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Zoltan Kis
 
-</section>
-
-<section id="transportation-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 Jennifer Lin, Michael McCool
 
-</section>
-
-<section id="transportation-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="transportation-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="transportation-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="transportation-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="transportation-sub-categories">
-<h4>Sub-categories</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Sub-categories</dt>
+<dd>
 Transportation - Infrastructure
 Transportation - Cargo
 Transportation - People
 
-</section>
-
-<section id="transportation-target users">
-<h4>Target Users</h4>
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 Smart Cities: managing roads, public transport and commuting, autonomous and human driven vehicles, transportation tracking and control systems, route information systems, commuting and public transport, vehicles, on-demand transportation, self driving fleets, vehicle information and control systems, infrastructure sharing and payment system, smart parking, smart vehicle servicing, emergency monitoring, etc.
 
@@ -1376,10 +3201,9 @@ Transport companies: managing shipping, air cargo, train cargo and last mile del
 Commuters: Mobility as a service, booking systems, route planning, ride sharing, self-driving, self-servicing infrastructure, etc.
 
 
-</section>
-
-<section id="transportation-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 Provide common vocabulary for describing transport related services and solutions that can be reused across sub-categories, for easier interoperability between various systems owned by different stakeholders.
 
@@ -1387,10 +3211,9 @@ Thing Description templates could be defined in many subdomains to help integrat
 
 Transportation of goods can be optimized at global level by enhancing interoperability between vertical systems.
 
-</section>
-
-<section id="transportation-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Road information system (routes, conditions, navigation).
 Road control system (e.g. virtual rails).
@@ -1405,33 +3228,30 @@ Electronic timetable management system.
 Vehicles (human driven, self-driving, isolated or part of fleet).
 Connected vehicles (cars, ships, airplanes, trains, buses etc).
 
-</section>
-
-<section id="transportation-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Vehicle data (identification, location, speed, route, selected vehicle data).
 Weather and climate data.
 Contextual data (representing various risk factors, delays, etc).
 
-</section>
-
-<section id="transportation-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 Localization technologies.
 Automotive data.
 Contextual data.
 Cloud integration.
 
-</section>
-
-<section id="transportation-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Transportation system implementers will be able to use a unified data description model accoss various systems.
 
-#### Variants:
+<p>#### Variants:</p>
 
 There will be different verticals, such as:
 
@@ -1443,97 +3263,90 @@ There will be different verticals, such as:
 <li>Cargo vehicle management</li>
 </ul>
 
-</section>
-
-<section id="transportation-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT work items&gt;
 
-</section>
-
-<section id="transportation-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 &lt;Provide links to relevant standards that are relevant for this use case&gt;
 
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="transportation-comments">
-<h4>Comments</h4>
-
-
-</section>
-
-<section id="Smart_Building">
 <section id="smart-building">
-<h3>Smart Building</h3>
+<h2>Smart Building</h2>
+<section id="smart-building">
+<h2>Smart Building</h2>
+<dl>
 
-<section id="smart-building-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Sebastian Kaebisch (Siemens)
 
-</section>
-
-<section id="smart-building-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 Michael Lagally (Oracle)
 
-</section>
-
-<section id="smart-building-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="smart-building-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="smart-building-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="smart-building-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="smart-building-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="smart-building-motivation and description">
-<h4>Motivation and Description</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
+
+</dd>
+<dt>Motivation and Description</dt>
+<dd>
 
 Buildings such as office buildings, hotels, airports, hospitals, train stations and sports stadiums typically consist of  heterogeneous IoT systems such as lightings, elevators, security (e.g., door control), air-conditionings, fire warnings, heatings, pools, parking control, etc. 
 
 Monitoring, controlling, and management of such a heterogeneous IoT landscape is quite chellanging in terms of engeneering and maintenance. 
 
-</section>
-
-<section id="smart-building-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
  
 All kind of sensors and actuators (e.g., HVAC).
 
-</section>
-
-<section id="smart-building-expected users">
-<h4>Expected Users</h4>
+</dd>
+<dt>Expected Users</dt>
+<dd>
 
 <ul>
 <li>systems engineers</li>
@@ -1541,79 +3354,73 @@ All kind of sensors and actuators (e.g., HVAC).
 <li>third party user</li>
 </ul>
 
-</section>
-
-<section id="smart-building-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Hetrogeneos data models from different IoT systems such as BACnet, KNX, and Modbus.
 
-</section>
-
-<section id="smart-building-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 WoT Thing Description and Thing Description Templates, WoT Architecture, WoT Binding Templates (covering protocol specifica)
 
 
-</section>
-
-<section id="smart-building-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 BACnet, KNX, OPC-UA, Modbus
 
+</dd>
+<dt>Comments</dt>
+<dd>
+</dd>
+</dl>
 </section>
-
-<section id="smart-building-comments">
-<h4>Comments</h4>
 <section id="connected-building-energy-efficiency">
-<h3>Connected Building Energy Efficiency</h3>
+<h2>Connected Building Energy Efficiency</h2>
+<dl>
 
-<section id="connected-building-energy-efficiency-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Farshid Tavakolizadeh (Fraunhofer)
 
-</section>
-
-<section id="connected-building-energy-efficiency-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 Michael McCool (Intel)
 
-</section>
-
-<section id="connected-building-energy-efficiency-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="connected-building-energy-efficiency-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="connected-building-energy-efficiency-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="connected-building-energy-efficiency-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="connected-building-energy-efficiency-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 <ul>
 <li>device owners</li>
@@ -1621,17 +3428,15 @@ Michael McCool (Intel)
 <li>directory service operator</li>
 </ul>
 
-</section>
-
-<section id="connected-building-energy-efficiency-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 Construction and renovation companies often deal with the challenge of delivering target energy-efficient buildings given specific budget and time constraints. Energy efficiency, as one of the key factors for renovation investments, depends on the availability of various data sources to support the renovation design and planning. These include climate data and building material along with residential comfort and energy consumption profiles. The profiles are created using a combination of manual inputs and sensory data collected from residents.
 
-</section>
-
-<section id="connected-building-energy-efficiency-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 <ul>
 <li>Gateway (e.g. Single-board computer with a Z-Wave controller)</li>
@@ -1649,46 +3454,42 @@ Z-wave Sensors:
 <li>Multi-sensors (Motion, Temperature, Light, Humidity, Vibration, UV)</li>
 </ul>
 
-</section>
-
-<section id="connected-building-energy-efficiency-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 <ul>
 <li>Ambient conditions</li>
 <li>Occupancy model</li>
 </ul>
 
-</section>
-
-<section id="connected-building-energy-efficiency-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 &lt;List the affected WoT deliverables that have to be changed to enable this use case&gt;
 
-</section>
-
-<section id="connected-building-energy-efficiency-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Renovation of residential buildings to improve energy efficiency depend on a wide range of sensory information to understand the building conditions and consumption models. As part of the pre-renovation activities, the renovation companies deploy various sensors to collect relevant data over a period of time. Such sensors become part of a wireless sensor network (WSN) and expose data endpoint with the help of one or more gateway devices. Depending on the protocols, the endpoints require different interaction flows to securely access the current and historical measurements. The renovation applications need to discover the sensors, their endpoints and how to interact with them based on search criteria such as the physical location, mapping to the building model or measurement type.
 
-#### Variants:
+<p>#### Variants:</p>
 
 &lt;Describe possible use case variants, if applicable&gt;
 
-#### Security Considerations:
+<p>#### Security Considerations:</p>
 
 &lt;Describe any issues related to security; if there are none, say "none" and justify&gt;
 
-#### Privacy Considerations:
+<p>#### Privacy Considerations:</p>
 
 The TD may expose personal information about the building layout and residents.
 
-</section>
-
-<section id="connected-building-energy-efficiency-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 There is no standard vocabulary for embedding application-specific meta data inside the TD. It is possible to extend the TD context and add additional fields but with too much flexibility, every application may end up with a completely different structure, making such information more difficult to discover. In this use-case, the application specific data are: 
 <ul>
@@ -1699,71 +3500,68 @@ There is no standard vocabulary for embedding application-specific meta data ins
 
 There is no standard API specification for the WoT Thing Directory to maintain and query TDs.
 
-</section>
-
-<section id="connected-building-energy-efficiency-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 <ul>
 <li><a href="https://www.ogc.org/standards/sensorthings) model includes a `properties` property for each Thing which is a non-normative JSON Object for application-specific information (not to be confused with TD's `properties` which is a Map of instances of PropertyAffordance">OGC SensorThings</a>.</li>
 </ul>
 
+</dd>
+<dt>Comments</dt>
+<dd>
+
+
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="connected-building-energy-efficiency-comments">
-<h4>Comments</h4>
-
-
-</section>
-
-<section id="Shared_Devices_and_Resources">
+<section id="shared-devices">
+<h2>Shared Devices and resources</h2>
 <section id="education">
-<h3>Shared Devices</h3>
+<h2>Shared Devices</h2>
+<dl>
 
-<section id="education-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Ege Korkan
 
-</section>
-
-<section id="education-reviewer">
-<h4>Reviewer(s)</h4>
-
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 
-</section>
 
-<section id="education-tracker issue id">
-<h4>Tracker Issue ID</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 <a href="https://github.com/w3c/wot-architecture/issues/496">496</a>
 
-</section>
-
-<section id="education-category">
-<h4>Category</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 Education
 
-</section>
-
-<section id="education-class">
-<h4>Class</h4>
-
-
-
-</section>
-
-<section id="education-status">
-<h4>Status</h4>
+</dd>
+<dt>Class</dt>
+<dd>
 
 
 
-</section>
+</dd>
+<dt>Status</dt>
+<dd>
 
-<section id="education-target users">
-<h4>Target Users</h4>
+
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 For the education category:
 
@@ -1774,17 +3572,15 @@ For the education category:
 <li>network operator : The university</li>
 </ul>
 
-</section>
-
-<section id="education-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 This use case motivates a standardized use of shared resources. One example is when a physical resource of the Thing should not be used by multiple Consumers at the same time like the arm of the robot but its position can be read my multiple Consumers.
 
-</section>
-
-<section id="education-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 Concrete devices are irrelevant for this use case but devices with a physical state is required. However, we have currently the following devices that are connected to Raspberry Pis where the WoT stack (node-wot or similar) is running. Concrete device models can be given upon request.
 
@@ -1799,122 +3595,113 @@ Concrete devices are irrelevant for this use case but devices with a physical st
 
 There are also IP Cameras but they are not WoT compatible and are not planned to be made compatible.
 
-</section>
-
-<section id="education-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Atmospheric data of a room, machine sensors
 
-</section>
-
-<section id="education-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 Thing Description, Scripting API, possibly security
 
-</section>
-
-<section id="education-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 We are offering a practical course for the students where they can interact fully remotely with WoT devices and verify their physical actions via video streams. We have sensors and actuators like robots. Students then build mashup applications to deepen their knowledge of WoT technologies. Official page of the course is <a href="https://campus.tum.de/tumonline/wbLv.wbShowLVDetail?pStpSpNr=950504601&pSpracheNr=1">here</a>.
 
-#### Variants:
+<p>#### Variants:</p>
 
-</section>
-
-<section id="education-security considerations">
-<h4>Security Considerations</h4>
+</dd>
+<dt>Security Considerations</dt>
+<dd>
 
 The devices are connected to the Internet and are secured behind a router and proxy.
 
-</section>
-
-<section id="education-privacy considerations">
-<h4>Privacy Considerations</h4>
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
 
 none from the WoT point of view since we want the devices to be used by anyone and the devices do not share any information that is related to the students or us as the provider of the devices.
 However, there are cameras which can show humans entering the room as a side effect (they are meant to monitor the devices). The streams are accessible only to authorized users, the room has signs on the door and there is a cage around the area that is filmed.
 
-</section>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
-<section id="education-gaps">
-<h4>Gaps</h4>
-
-#### Thing Description
+<p>#### Thing Description</p>
 
 <ul>
 <li>How to give hints that a particular action should not be used by others at the same time. A new keyword (like `"shared":true`) would be needed for devices that do not implement a describable mechanism.</li>
 <li>How to describe the mechanism that the Thing implements to manage the shared resources. Does it happen in the security level? </li>
 </ul>
 
-#### Scripting API
+<p>#### Scripting API</p>
 
 <ul>
 <li>How does the Consumer code change when this mechanism is used. Does it get settled in the implementation or scripting level. </li>
 </ul>
 
+</dd>
+<dt>Existing standards</dt>
+<dd>
+
+
+</dd>
+<dt>Comments</dt>
+<dd>
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="education-existing standards">
-<h4>Existing standards</h4>
-
-
-</section>
-
-<section id="education-comments">
-<h4>Comments</h4>
-</section>
-
-<section id="OAuth2_Flows">
+<section id="oauth2-flow">
+<h2>Oauth2 Flows</h2>
 <section id="oauth">
-<h3>OAuth2 Flows</h3>
+<h2>OAuth2 Flows</h2>
+<dl>
 
-<section id="oauth-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Michael McCool, Cristiano Aguzzi
 
-</section>
-
-<section id="oauth-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 &lt;Suggest reviewers&gt;
 
-</section>
-
-<section id="oauth-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="oauth-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="oauth-class">
-<h4>Class</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="oauth-status">
-<h4>Status</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
 
 WIP
 
-</section>
-
-<section id="oauth-target users">
-<h4>Target Users</h4>
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 <ul>
 <li>device owner</li>
@@ -1925,10 +3712,9 @@ WIP
 <li>directory service</li>
 </ul>
 
-</section>
-
-<section id="oauth-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 
 OAuth 2.0 is an authorization protocol widely known for its usage across several web services.
@@ -1942,9 +3728,9 @@ The protocol defines the following actors:
 <li>Resource: a web resource </li>
 <li>Resource Server: the server where the resource is stored</li>
 <li>Resource Owner: the owner of a particular web resource. If it is a human is usually referred to as an end-user.</li>
-</ul>
   More specifically from the RFC:
   &gt;  An entity capable of granting access to a protected resource.
+</ul>
 
 
 These actors can be mapped to WoT entities: 
@@ -1953,20 +3739,18 @@ These actors can be mapped to WoT entities:
 <li>Authorization Server is a third-party service</li>
 <li>Resource is an interaction affordance</li>
 <li>Resource Server is a Thing described by a Thing Description acting as a server.  </li>
-</ul>
   May be a device or a service.
-<ul>
 <li>Resource Owner might be different in each use case.</li>
-</ul>
   A Thing Description may also combine resources from different owners or web server.
   
 TO DO: Check the OAuth 2.0 spec to determine exactly how Resource Owner is defined.
 Is it the actual owner of the resource (eg running the web server) or simply someone
 with the rights to access that resource?
+</ul>
 
 The OAuth 2.0 protocol specifies an authorization layer that separates the client from the resource owner.
 The basic steps of this protocol are summarized in the following diagram:
-
+<pre>
      +--------+                               +---------------+
      |        |--(A)- Authorization Request -&gt;|   Resource    |
      |        |                               |     Owner     |
@@ -1984,7 +3768,7 @@ The basic steps of this protocol are summarized in the following diagram:
      |        |                               |     Server    |
      |        |&lt;-(F)--- Protected Resource ---|               |
      +--------+                               +---------------+
-
+</pre>
 Steps A and B defines what is known as authorization grant type or flow.
 What is important to realize here is that not all of these interactions
 are meant to take place over a network protocol.
@@ -2014,10 +3798,9 @@ required by the interaction.
 
 This document describes relevant use cases for each of the OAuth 2.0 authorization flows. 
 
-</section>
-
-<section id="oauth-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 To support OAuth 2.0, all devices must have the capability of: 
 <ul>
@@ -2028,17 +3811,14 @@ To support OAuth 2.0, all devices must have the capability of:
 Comment: 
 <ul>
 <li>Investigate whether DTLS can be used.</li>
-</ul>
   Certainly the connection needs to be encrypted; this is required in the OAuth 2.0 specification.
-<ul>
 <li>Investigate whether protocols other than HTTP can be used, e.g. CoAP.</li>
-</ul>
   - found an interesting IETF draft RFC about CoAP  support(encrypted using various mechanisms like DTLS or CBOR Object Signing and Encryption): <a href="https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-35">draft-ietf-ace-oauth</a>
+</ul>
 
-</section>
-
-<section id="oauth-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 Depending on the OAuth 2.0 flow specified, various URLs and elements need to be specified,
 for example, the location of an authorization token server.
@@ -2048,17 +3828,15 @@ Finally,
 OAuth 2.0 supports scopes so these need to be defined in the security scheme and specified in
 the form.
 
-</section>
-
-<section id="oauth-dependencies - affected wot deliverables and/or work items">
-<h4>Dependencies - Affected WoT deliverables and/or work items</h4>
+</dd>
+<dt>Dependencies - Affected WoT deliverables and/or work items</dt>
+<dd>
 
 Thing Description, Scripting API, Discovery, and Security. 
 
-</section>
-
-<section id="oauth-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 A general use case for OAuth 2.0 is when a WoT consumer wants to access restricted interaction affordances.
 In particular, when those affordances have a specific resource owner which 
@@ -2066,7 +3844,7 @@ may grant some temporary permissions to the consumer.
 
 The WoT consumer can either be hosted in a remote device or interact directly with the end-user inside an application.
 
-#### Variants:
+<p>#### Variants:</p>
 
 For each OAuth 2.0 flow, there is a corresponding use case variant.
 We also include the experimental "device" flow for consideration.
@@ -2091,7 +3869,7 @@ This implies that the code flow can be only used when the resource owner interac
 </ul>
 
 The following diagram shows the steps of the protocol adapted to WoT idioms and entities. In this scenario, the WoT Consumer has read the Thing Description of a Remote Device and want to access one of its WoT Affordances protected with OAuth 2.0 code flow.  
-```
+<pre>
                                                  +-----------+
   +----------+                                   |           |
   | Resource |                                   |  Remote   |
@@ -2122,14 +3900,14 @@ The following diagram shows the steps of the protocol adapted to WoT idioms and 
       |                                                               |
       +-----------(F)----- Access WoT --------------------------------+
                            Affordance
-```
+</pre>
 Notice that steps (A), (B) and (C) are broken in two parts as they pass through the User-Agent. 
 
 
 ##### device
 
 The device flow (IETF <a href="https://tools.ietf.org/html/rfc8628#section-6.2) briefly describes an authentication using a companion app and BLE), as shown in the following (slightly adapted">RFC 8628](https://tools.ietf.org/html/rfc8628)) is a variant of the code flow for browserless and input-constrained devices. Similarly, to its *parent* flow, it requires a close interaction between the resource owner and the WoT consumer. Therefore, the use cases for this flow are the same as the code authorization grant but restricted to all devices that do not have a rich means to interact with the resource owner. However, differently from `code`, RFC 8628 states explicitly that one of the actors of the protocol is an **end-user** interacting with a **browser** (even if [section-6.2</a> diagram:
-```
+<pre>
 +----------+
 |          |
 |  Remote  |
@@ -2162,13 +3940,11 @@ The device flow (IETF <a href="https://tools.ietf.org/html/rfc8628#section-6.2) 
 |    at    +&lt;---(D)-- End user reviews  ---&gt;+                |
 |  Browser |          authorization request |                |
 +----------+                                +----------------+
-```
+</pre>
 Notable mentions:
 <ul>
 <li>the protocol is heavily end-user oriented. In fact, the RFC states the following</li>
-</ul>
   &gt; Due to the polling nature of this protocol (as specified in Section 3.4), care is needed to avoid overloading the capacity of the token endpoint.  To avoid unneeded requests on the token endpoint, the client SHOULD only commence a device authorization request when **prompted by the user and not automatically**, such as when the app starts or when the previous authorization session expires or fails.
-<ul>
 <li>TLS is required both between WoT Consumer/Authorization Server and between Browser/Authorization Server</li>
 <li>Other user interactions methods may be used but are left out of scope</li>
 </ul>
@@ -2194,7 +3970,7 @@ Therefore the client credential grant can be used:
 
 The Client Credentials flow is illustrated in the following diagram. Notice how the Resource Owner is not present. 
 
-```
+<pre>
 +----------+
 |          |
 |  Remote  |
@@ -2212,8 +3988,7 @@ The Client Credentials flow is illustrated in the following diagram. Notice how 
 |          |                                  |               |
 |          |                                  +---------------+
 +----------+
-```
-
+</pre>
 Comment: Usually client credentials are distributed using an external service which is used by humans to register a particular application. For example, the `npm` cli has a companion dashboard where a developer requests the generation of a token that is then passed to the cli. The token is used to verify the publishing process of `npm` packages in the registry. Further examples are Docker cli and OpenId Connect Client Credentials. 
 
 ##### implicit
@@ -2234,7 +4009,7 @@ Considering the WoT context this flow is not particularly different from `code` 
 
 Comment: even if the `implicit` flow is deprecated existing services may still using it. 
 
-```
+<pre>
 +----------+
 | Resource |
 |  Owner   |
@@ -2269,7 +4044,7 @@ Comment: even if the `implicit` flow is deprecated existing services may still u
 |          |                                   +----------+
 +----------+
 
-```
+</pre>
 
 ##### resource owner password
 **Deprecated** From  <a href="https://tools.ietf.org/html/draft-ietf-oauth-security-topics-15#section-2.1.2">OAuth 2.0 Security Best Current Practice</a>:
@@ -2283,7 +4058,7 @@ Comment: even if the `implicit` flow is deprecated existing services may still u
 
 For completeness the diagram flow is reported below.  
 
-```
+<pre>
  +----------+
  | Resource |
  |  Owner   |
@@ -2309,145 +4084,134 @@ For completeness the diagram flow is reported below.
  |  Device  |
  |          |
  +----------+
-```
+</pre>
 
 
-</section>
-
-<section id="oauth-security considerations">
-<h4>Security Considerations</h4>
+</dd>
+<dt>Security Considerations</dt>
+<dd>
 
 See OAuth 2.0 security considerations in <a href="https://tools.ietf.org/html/rfc8628#section-5">RFC6749](https://tools.ietf.org/html/rfc6749#section-10). See also [RFC 8628 section 5</a> for `device` flow.
 
-</section>
-
-<section id="oauth-privacy considerations">
-<h4>Privacy Considerations</h4>
+</dd>
+<dt>Privacy Considerations</dt>
+<dd>
 
 &lt;Describe any issues related to privacy; if there are none, say "none" and justify&gt;
 
-</section>
-
-<section id="oauth-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 &lt;Describe any gaps that are not addressed in the current WoT standards and building blocks&gt;
 
-</section>
-
-<section id="oauth-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 &lt;Provide links to relevant standards that are relevant for this use case&gt;
 
-</section>
-
-<section id="oauth-comments">
-<h4>Comments</h4>
+</dd>
+<dt>Comments</dt>
+<dd>
 Notice that the OAuth 2.0 protocol is not an authentication protocol, however <a href="https://openid.net/connect/">OpenID</a> defines an authentication layer on top of OAuth 2.0.
+</dd>
+</dl>
+</section>
 </section>
 
-<section id="Device_Lifecycle">
 <section id="device-lifecycle">
-<h3>Device Lifecycle</h3>
+<h2>Device Lifecycle</h2>
+<section id="device-lifecycle">
+<h2>Device Lifecycle</h2>
+<dl>
 
-<section id="device-lifecycle-submitter">
-<h4>Submitter(s)</h4>
+<dt>Submitter(s)</dt>
+<dd>
 
 Michael Lagally
 
-</section>
-
-<section id="device-lifecycle-reviewer">
-<h4>Reviewer(s)</h4>
+</dd>
+<dt>Reviewer(s)</dt>
+<dd>
 
 All WoT Arch participants
 
-</section>
-
-<section id="device-lifecycle-tracker issue id">
-<h4>Tracker Issue ID</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="device-lifecycle-category">
-<h4>Category</h4>
+</dd>
+<dt>Tracker Issue ID</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
-
-<section id="device-lifecycle-class">
-<h4>Class</h4>
-
-&lt;please leave blank&gt;
-
-</section>
-
-<section id="device-lifecycle-status">
-<h4>Status</h4>
+</dd>
+<dt>Category</dt>
+<dd>
 
 &lt;please leave blank&gt;
 
-</section>
+</dd>
+<dt>Class</dt>
+<dd>
 
-<section id="device-lifecycle-target users">
-<h4>Target Users</h4>
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Status</dt>
+<dd>
+
+&lt;please leave blank&gt;
+
+</dd>
+<dt>Target Users</dt>
+<dd>
 
 device manufacturer, gateway manufacturer, cloud provider
 
-</section>
-
-<section id="device-lifecycle-motivation">
-<h4>Motivation</h4>
+</dd>
+<dt>Motivation</dt>
+<dd>
 
 Current spec does not address lifecycle.
 
-</section>
-
-<section id="device-lifecycle-expected devices">
-<h4>Expected Devices</h4>
+</dd>
+<dt>Expected Devices</dt>
+<dd>
 
 
 &lt;List the target devices, e.g. as a sensor, solar panel, air conditioner&gt;
 
-</section>
-
-<section id="device-lifecycle-expected data">
-<h4>Expected Data</h4>
+</dd>
+<dt>Expected Data</dt>
+<dd>
 
 &lt;List the type of expected data, e.g. weather and climate data, medical conditions, machine sensors, vehicle data&gt;
 
-</section>
-
-<section id="device-lifecycle-dependencies">
-<h4>Dependencies</h4>
+</dd>
+<dt>Dependencies</dt>
+<dd>
 
 &lt;List the affected WoT deliverables&gt;
 
-</section>
-
-<section id="device-lifecycle-description">
-<h4>Description</h4>
+</dd>
+<dt>Description</dt>
+<dd>
 
 Handle the entire device lifecycle: 
 Define terminology for lifecycle states and transitions.
 
-#### Actors (represent a physical person or group of persons (company))
+<p>#### Actors (represent a physical person or group of persons (company))</p>
 Manufacturer
 Service Provider
 Network Provider (potentially transparent for WoT use cases)
 Device Owner (User)
 Others?
 
-#### Roles:
+<p>#### Roles:</p>
 Depending on the use case, an actor can have multiple roles, 
 e.g. security maintainer.  
 Roles can be delegated.
 
-#### Variants:
+<p>#### Variants:</p>
 
 There are (at least) two different entities to consider:
 <ul>
@@ -2461,10 +4225,9 @@ In more complex use cases there are additional entities:
 <li>Directories</li>
 </ul>
 
-</section>
-
-<section id="device-lifecycle-gaps">
-<h4>Gaps</h4>
+</dd>
+<dt>Gaps</dt>
+<dd>
 
 The current architecture spec does not describe device lifecycle in detail.
 A common lifecycle model helps to clarify terminology and structures the discussion
@@ -2472,10 +4235,9 @@ in different groups.
 Interaction of a device with other entities such as directories may introduce 
 additional states and transitions.
 
-</section>
-
-<section id="device-lifecycle-existing standards">
-<h4>Existing standards</h4>
+</dd>
+<dt>Existing standards</dt>
+<dd>
 
 &lt;Provide links to relevant standards that are relevant for this use case&gt;
 WoT Security
@@ -2487,10 +4249,9 @@ SIM cards / GSMA
 IETF 
 Application Lifecycle (W3C Multimodal Interaction WG)  
 
-</section>
-
-<section id="device-lifecycle-comments">
-<h4>Comments</h4>
+</dd>
+<dt>Comments</dt>
+<dd>
 
 All lifecycle contributions and discussion documents are available at:
 https://github.com/w3c/wot-architecture/blob/master/proposals/lifecycle
@@ -2517,9 +4278,13 @@ IoT Security Bootstrapping:
 https://github.com/w3c/wot-security/blob/master/presentations/2020-03-16-Bootstrapping%20IoT%20Security%20-%20The%20IETF%20Anima%20and%20OPC-UA%20Recipes.pdf
 
 
+</dd>
+</dl>
+</section>
 </section>
 
-<!--		
+
+<!--
 Domains from the 1.0 UC document 
 		
 		<section id="domain-home_automation">


### PR DESCRIPTION
The updated [index.html](https://w3c.github.io/wot-usecases/#use-cases) includes all the proposed use cases at the [USE-CASES area](https://github.com/w3c/wot-usecases/tree/master/USE-CASES). However, the format is actually not well-readable because I used &lt;h3&gt;, &lt;h4&gt;, etc. (sorry)

Therefore I modified the [md2html.pl](https://github.com/w3c/wot-usecases/blob/master/CONTRIBUTIONS/md2html.pl) to use &lt;h2&gt; for headings and &lt;dl&gt; for the labels of each use case description.

I believe this modification significantly improves the readability for further edits.

Please see also the preview below.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/36.html" title="Last updated on Aug 6, 2020, 7:49 AM UTC (acabe0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/36/67fdf33...acabe0b.html" title="Last updated on Aug 6, 2020, 7:49 AM UTC (acabe0b)">Diff</a>