### PR TITLE
move reference section into head section

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,265 @@
           date: "2008-07",
           publisher: "ISO"
         },
-
+        "Hybridcast": { 
+          title: "Hybridcast",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "..",
+          publisher: "..."
+        },
+        "NMEA": { 
+          title: "National Marine Electronics Association",
+          href: "https://www.nmea.org",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "WGS84": { 
+          title: "WGS84",
+          href: "https://en.wikipedia.org/wiki/World_Geodetic_System",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "Basic Geo Vocabulary": { 
+          title: "W3C Semantic Web Interest Group",
+          href: "https://www.w3.org/2003/01/geo/",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "W3C Geolocalization API": { 
+          title: "Geolocation API Specification 2nd Edition",
+          href: "https://www.w3.org/TR/geolocation-API/",
+          authors: ["Andrei Popescu"],
+          status: "Published",
+          date: "8 Nov 2016",
+          publisher: "W3C"
+        },
+        "Open Geospatial Consortium": { 
+          title: "Open Geospatial Consortium",
+          href: "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "ISO19111": { 
+          title: "ISO19111",
+          href: "https://www.iso.org/standard/74039.html",
+          authors: ["..."],
+          status: "Published",
+          date: "Jan 2019",
+          publisher: "ISO"
+        },
+        "SSN": { 
+          title: "Semantic Sensor Network Ontology",
+          href: "https://www.w3.org/TR/vocab-ssn/",
+          authors: [
+            "Armin Haller",
+            "Krzysztof Janowicz",
+            "Simon Cox",
+            "Danh Le Phuoc",
+            "Kerry Taylor",
+            "Maxime Lefrançois"
+           ],
+          status: "Published",
+          date: "19 Oct 2017",
+          publisher: "W3C"
+        },
+        "Timestamps": { 
+          title: "Timestamps",
+          href: "https://w3c.github.io/hr-time/#dom-domhighrestimestamp",
+          authors: ["Ilya Grigorik"],
+          status: "...",
+          date: "06 Oct 2020",
+          publisher: "W3C"
+        },
+        "MMI UC3.1": {
+          title: "MMI UC3.1",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MMI UC3.2": { 
+          title: "MMI UC3.2",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "ICE F2761-09(2013)": { 
+          title: "ICE F2761-09(2013)",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "OpenICE": { 
+          title: "OpenICE",
+          href: "https://www.openice.info",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MDIRA": { 
+          title: "MDIRA",
+          href: "https://secwww.jhuapl.edu/mdira/documents",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MQTT": { 
+          title: "MQTT Version 3.1.1 Plus Errata 01",
+          href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html",
+          authors: ["Andrew Banks", "Rahul Gupta"],
+          status: "...",
+          date: "December 2015",
+          publisher: "OASIS Standard"
+        },
+        "OPC UA": { 
+          title: "OPC Unified Architecture",
+          href: "https://opcfoundation.org/about/opc-technologies/opc-ua/",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "OPC"
+        },
+        "BACnet": { 
+          title: "BACnet",
+          href: "http://www.bacnet.org",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "CoAP": { 
+          title: "The Constrained Application Protocol (CoAP)",
+          href: "https://tools.ietf.org/html/rfc7252",
+          authors: [
+            "Z. Shelby",
+            "K. Hartke",
+            "C. Bormann"
+           ],
+          status: "Published",
+          date: "June 2014",
+          publisher: "IETF"
+        },
+        "MMI UC5.1": { 
+          title: "MMI UC5.1",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MMI UC5.2": { 
+          title: "MMI UC5.2",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        ".MMI UC1.1": { 
+          title: "MMI UC1.1",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MMI UC1.2": { 
+          title: "MMI UC1.2",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "MMI UC2.1": { 
+          title: "MMI UC2.1",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "IEC 61850": { 
+          title: "IEC 61850",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "IEEE 1574": { 
+          title: "IEEE 1574",
+          href: "...",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "KNX": { 
+          title: "KNX",
+          href: "https://www.knx.org/knx-en/for-professionals/index.php",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "Modbus": { 
+          title: "Modbus",
+          href: "https://modbus.org",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "OGC Sensor Things": { 
+          title: "OGC Sensor Things API",
+          href: "https://www.ogc.org/standards/sensorthings",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "OneM2M": { 
+          title: "OneM2M",
+          href: "https://www.onem2m.org",
+          authors: ["..."],
+          status: "...",
+          date: "...",
+          publisher: "..."
+        },
+        "LWM2M": { 
+          title: "Lightweight Machine to Machine Technical Specification: Core",
+          href: "http://openmobilealliance.org/release/LightweightM2M/V1_1-20180710-A/OMA-TS-LightweightM2M_Core-V1_1-20180710-A.pdf",
+          authors: ["..."],
+          status: "...",
+          date: "Aug 2018",
+          publisher: "OMA SpecWorks."
+        },
+        "OCF": { 
+          title: "OCF Core Specification",
+          href: "https://openconnectivity.org/developer/specifications",
+          authors: ["..."],
+          status: "...",
+          date: "April 2019",
+          publisher: "Open Connectivity Foundation"
+        },
       }
     };
   </script>
@@ -6384,6 +6642,7 @@
       </p>
     </section>
 
+    <!--
     <section id="references" class="appendix">
       <h2 id="a-references"><bdi class="secno">A.</bdi>
         References<a class="self-link" aria-label="§" href="#references"></a></h2>
@@ -6568,6 +6827,9 @@
         </dl>
       </section>
     </section>
+  -->
+
+  
 
     <!--
 Domains from the 1.0 UC document 


### PR DESCRIPTION
I rewote the reference section to fix tre respec format and moved the head section. And I commented out the reference section.

But there were not enough the information of each references. So  I added the information that I was able to look up. But It was not enough. I think we should check them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/72.html" title="Last updated on Dec 8, 2020, 12:00 PM UTC (08c1c44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/72/4def1c6...08c1c44.html" title="Last updated on Dec 8, 2020, 12:00 PM UTC (08c1c44)">Diff</a>