### PR TITLE
Hybridcast Reference Infromation

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,7 +856,7 @@
           <dt>Existing standards</dt>
           <dd>
 
-            Hybridcast and Hybridcast Connect: a Japanese Integrated Broadcast-Broadband system,
+            Hybridcast and Hybridcast Connect: a Japanese Integrated Broadcast-Broadband system (<a href="http://www.iptvforum.jp/download/input.html">IPTVFJ STD-0013 "Hybridcast Operational Guideline Version 2.8" (Application Forms)</a>, <a href="https://github.com/nhkrd">Reference Implementations</a>),
             HbbTV,
             ATSC 3.0,
             ...etc.


### PR DESCRIPTION
I added reference link about Hybridcast.

- [IPTVFJ STD-0013 "Hybridcast Operational Guideline Version 2.8" (application forms)](http://www.iptvforum.jp/download/input.html)
- [Reference Implementations (our github repositories)](https://github.com/nhkrd)

Could you please confirm it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abes-jg/wot-usecases/pull/73.html" title="Last updated on Dec 16, 2020, 12:33 AM UTC (b7e6580)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/73/be363fc...abes-jg:b7e6580.html" title="Last updated on Dec 16, 2020, 12:33 AM UTC (b7e6580)">Diff</a>