### PR TITLE
use short name wot-usecases, remove company names in section 2.3.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       noRecTrack: "true",
       maxTocLevel: 6,
       processVersion: 2019,
-      shortName: "wot-use-cases-requirements",
+      shortName: "wot-usecases",
       copyrightStart: 2020,
       group: "ig/wot",
       edDraftURI: "https://w3c.github.io/wot-usecases/",
@@ -2188,12 +2188,7 @@
 
           <dt>Submitter(s)</dt>
           <dd>
-            <p><a href="https://orcid.org/0000-0002-5672-5508">Edison Chung (MINES St. Etienne)</a></br>
-              <a href="https://orcid.org/0000-0001-7604-8543">Hervé Pruvost (Fraunhofer IIS EAS)</a></br>
-              <a href="https://orcid.org/0000-0002-2033-859X">Georg Ferdinand Schneider (Schaeffler Technologies
-                AG)</a>
-            </p>
-
+            Edison Chung, Hervé Pruvost, Georg Ferdinand Schneider
           </dd>
           <!--dt>Reviewer(s)</dt>
           <dd>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/130.html" title="Last updated on May 4, 2021, 1:12 PM UTC (8b51826)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/130/5a30db5...8b51826.html" title="Last updated on May 4, 2021, 1:12 PM UTC (8b51826)">Diff</a>