### PR TITLE
fix resize CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
     };
   </script>
   <style>
-   .resize img { width: 100%; }
+   .resize img { width: 100%; height: auto;}
   </style>
 </head>
 
@@ -4216,7 +4216,7 @@
         
         <dt>Description</dt>
         <dd>
-        <img src="./images/wot-use-case-echonet.png" alt="echonet use case" />
+            <div class="resize"><img src="./images/wot-use-case-echonet.png" alt="echonet use case" /></div>>
         
         <ul>
         <li>Configuration by a device user before starting to use a service


### PR DESCRIPTION
* the aspect ratio of the NHK's diagram (scenario_nhk.png) was broken
    * added "height: auto;" to the CSS setting for "resize" class
* the width of the ECHONET diagram (wot-use-case-echoet.png) was too wide
    * added <div class="resize"> to apply the (fixed version of) CSS setting above to make the width of the diagram 100% of the document


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/146.html" title="Last updated on Sep 27, 2021, 7:16 PM UTC (92149e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/146/4294f06...92149e7.html" title="Last updated on Sep 27, 2021, 7:16 PM UTC (92149e7)">Diff</a>