### PR TITLE
EdgeX Liaison Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7048,15 +7048,16 @@
     <section id="edgex">
       <h2>EdgeX Foundry</h2>
       <p>
-        The EdgeX Foundry [EDGEX] is a community-driven open source project,
-        organized under the Linux Foundation, to build
-        a secure software stack for IoT hubs. Its goal is to enable interoperability
+        The EdgeX Foundry [EDGEX] is a community-driven project,
+        organized under the Linux Foundation, to define
+        a reference software architecture for IoT hubs. 
+        Its goal is to enable interoperability
         by combining a set of key IoT services with a set of interfaces to a variety
-        of IoT device protocols and ecosystems.  This organization focuses on software
-        development rather than standards development per se.  
+        of IoT device protocols and ecosystems.  
+        There is a reference implementation of the EdgeX architecture.
       </p>
       <p>
-        EdgeX Foundry provides a set of protocol translation services and exposes
+        The EdgeX Foundry reference architecture provides a set of protocol translation services and exposes
         interfaces to a variety of ecosystems and devices.  However, it currently
         lacks a standard and IoT-appropriate metadata standard to describe the device interfaces
         (and the data models for those interfaces) that it exposes on the network.

--- a/index.html
+++ b/index.html
@@ -92,8 +92,11 @@
         },
         "NMEA": {
           title: "National Marine Electronics Association",
-          href: "https://www.nmea.org",
-
+          href: "https://www.nmea.org"
+        },
+        "EDGEX": {
+          title: "EdgeX Foundry",
+          href: "https://www.edgexfoundry.org/"
         },
         "WGS84": {
           title: "WGS84",
@@ -7043,11 +7046,23 @@
     </section>
 
     <section id="edgex">
-      <h2>EdgeX (McCool)</h2>
-      <section id="liaison-6" class="ednote">
-        TODO: Brief description of liaised SDO, work areas.
-        Scope of the collaboration.
-        Provide Website link.
+      <h2>EdgeX Foundry</h2>
+      <p>
+        The EdgeX Foundry [EDGEX] is a community-driven open source project,
+        organized under the Linux Foundation, to build
+        a secure software stack for IoT hubs. Its goal is to enable interoperability
+        by combining a set of key IoT services with a set of interfaces to a variety
+        of IoT device protocols and ecosystems.  This organization focuses on software
+        development rather than standards development per se.  
+      </p>
+      <p>
+        EdgeX Foundry provides a set of protocol translation services and exposes
+        interfaces to a variety of ecosystems and devices.  However, it currently
+        lacks a standard and IoT-appropriate metadata standard to describe the device interfaces
+        (and the data models for those interfaces) that it exposes on the network.
+        The WoT Thing Description could fulfill this role; otherwise, the EdgeX Foundry
+        architecture fits within the general framework of a WoT system. 
+      </p>
       </section>
     </section>
   <!-- Acknowledgements -->


### PR DESCRIPTION
Description of EdgeX and WoT's relationship to it.  Note that this should be carefully reviewed for accuracy, we don't want to misrepresent a potential partner's project.  In particular, we need to check if they have adopted another mechanism for formally expressing metadata (e.g. OpenAPI) since I last looked at it in detail.

Also, EdgeX is basically an example of a software stack for a "hub" architecture.  There are several other examples of such architectures, including WebThings, SmartThings, Hubicity, etc.  So I have listed some related issues in architecture (see below) that relate to this.  Also, it seems to me that if we are going to talk about EdgeX we probably want to also talk about WebThings and maybe mention some of the other ones (there is a list in the issues of the wot-security repo).

Related issues:
- https://github.com/w3c/wot-usecases/issues/45
- https://github.com/w3c/wot-architecture/issues/585
- https://github.com/w3c/wot-architecture/issues/581


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-usecases/pull/158.html" title="Last updated on Dec 14, 2021, 1:16 PM UTC (3d7f5ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/158/4a01cdc...mmccool:3d7f5ad.html" title="Last updated on Dec 14, 2021, 1:16 PM UTC (3d7f5ad)">Diff</a>