### PR TITLE
commenting liaison sections without contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -8471,7 +8471,7 @@
       and additional liaisons are under consideration.
     </p>
 
-    <section id="itu-t">
+<!--     <section id="itu-t">
       <h2>ITU-T SG20 (Kaz/McCool/Sebastian)</h2>
       <section id="liaison-1" class="ednote">
         <section id="liaison-5" class="ednote">
@@ -8489,7 +8489,7 @@
           Provide Website link.  
       </section>
     </section>
-
+ -->
     <section id="echonet">
       <h2>ECHONET Consortium</h2>
       <section id="liaison-3">
@@ -8542,7 +8542,7 @@
       </p>
     </section>
 
-    <section id="iso-tc184">
+<!--     <section id="iso-tc184">
       <h2>ISO TC184/SC4 (Sebastian/Kaz)</h2>
       <section id="liaison-5" class="ednote">
         TODO: Brief description of liaised SDO, work areas.
@@ -8550,7 +8550,7 @@
         Provide Website link.
       </section>
     </section>
-
+ -->
     <section id="edgex">
       <h2>EdgeX Foundry</h2>
       <p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/169.html" title="Last updated on Dec 14, 2021, 1:42 PM UTC (7fc29b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/169/5529421...7fc29b6.html" title="Last updated on Dec 14, 2021, 1:42 PM UTC (7fc29b6)">Diff</a>