### PR TITLE
Update Health Privacy Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4609,7 +4609,7 @@
             <dt>References</dt>
             <dd>
               Standards relevant to this use case include regional standards for the management of personal health data, 
-              including but not limited to [[HIPPA]] in the United States, [[GDPR]] in the EU, and [[PIPEDA]] in Canada.
+              including but not limited to [[HIPAA]] in the United States, [[GDPR]] in the EU, and [[PIPEDA]] in Canada.
             </dd>
             <dt>Gaps</dt>
             <dd>

--- a/index.html
+++ b/index.html
@@ -4602,17 +4602,12 @@
             </dd>
             <!--dt>Privacy Considerations</dt>
             <dd>
-
-              <!- -section id="todo-privacy-2" class="ednote">TODO: Describe any issues related to privacy; if there are
-                none,
-                say "none" and justify</section>
-
+             Medical applications need to be conformant with the appropriate medical privacy standards.
             </dd>
             <dt>References</dt>
             <dd>
-              <section id="todo-references-x" class="ednote">TODO: Provide links to relevant standards that are relevant
-                for this use case</section>
-
+              Standards relevant to this use case include regional standards for the management of personal health data, 
+              including but not limited to [[HIPPA]] in the United States, [[GDPR]] in the EU, and [[PIPEDA]] in Canada.
             </dd-->
             <dt>Gaps</dt>
             <dd>

--- a/index.html
+++ b/index.html
@@ -90,9 +90,11 @@
           date: "..",
           publisher: "..."
         },
-        "NMEA": {
-          title: "National Marine Electronics Association",
-          href: "https://www.nmea.org"
+        "HIPAA": {
+          title: "The Health Insurance Portability and Accountability Act of 1996 (HIPAA), Public Law 104-191",
+          href: "https://www.hhs.gov/hipaa/index.html",
+          date: "1996-08-21",
+          publisher: "U.S. Department of Health and Human Services (HHS)"
         },
         "EDGEX": {
           title: "EdgeX Foundry",
@@ -4581,7 +4583,7 @@
             <dd>
               <p>
                 Security considerations for interconnected and dynamically composable medical systems are critical not
-                only because laws such as <a href="https://www.hhs.gov/hipaa/index.html">HIPAA</a> mandate it, but also
+                only because laws such as [[HIPAA]] mandate it, but also
                 because security attacks can have serious safety consequences for patients. The systems need to support
                 automatic verification that the system components are being used as intended in the clinical context,
                 that the components are authentic and authorized for use in that environment, that they have been
@@ -4600,15 +4602,15 @@
                 and performance. Another issue with widely used transport-level security solutions is the lack of
                 support for multicast.
             </dd>
-            <!--dt>Privacy Considerations</dt>
+            <dt>Privacy Considerations</dt>
             <dd>
-             Medical applications need to be conformant with the appropriate medical privacy standards.
+             Medical applications need to be conformant with the appropriate medical privacy standards and legal requirements.
             </dd>
             <dt>References</dt>
             <dd>
               Standards relevant to this use case include regional standards for the management of personal health data, 
               including but not limited to [[HIPPA]] in the United States, [[GDPR]] in the EU, and [[PIPEDA]] in Canada.
-            </dd-->
+            </dd>
             <dt>Gaps</dt>
             <dd>
 

--- a/index.html
+++ b/index.html
@@ -96,6 +96,13 @@
           date: "1996-08-21",
           publisher: "U.S. Department of Health and Human Services (HHS)"
         },
+        "GDPR": {
+          title: "General Data Protection Regulation (GDPR), EU Public Law 104-191",
+          version: "OJ L 119, 04.05.2016; cor. OJ L 127, 23.5.2018",
+          date: "2018-05-23",
+          href: "https://gdpr-info.eu/",
+          publisher: "European Union"
+        },
         "EDGEX": {
           title: "EdgeX Foundry",
           href: "https://www.edgexfoundry.org/"

--- a/index.html
+++ b/index.html
@@ -103,6 +103,12 @@
           href: "https://gdpr-info.eu/",
           publisher: "European Union"
         },
+        "PIPEDA": {
+          title: "Personal Information Protection and Electronic Documents Act (PIPEDA)",
+          href: "https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/",
+          date: "2000-04-13",
+          publisher: "Government of Canada, Office of the Privacy Commissioner"
+        },
         "EDGEX": {
           title: "EdgeX Foundry",
           href: "https://www.edgexfoundry.org/"


### PR DESCRIPTION
- Add (small modification of) agreed-upon sentence for health privacy section saying that relevant privacy standards should be followed
- Add citations of HIPPA, GDPR, and PIPEDA
- Add local references for each of HIPAA, GDPR, and PIPEDA (not in SpecRef database)

Resolves https://github.com/w3c/wot-usecases/issues/50


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/175.html" title="Last updated on Jan 25, 2022, 3:19 PM UTC (0c3ed48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/175/e58da67...0c3ed48.html" title="Last updated on Jan 25, 2022, 3:19 PM UTC (0c3ed48)">Diff</a>