### PR TITLE
Update References

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,15 @@
 	  date: "6 June 2019",
 	  publisher: "ETSI",
 	  href: "https://saref.etsi.org/saref4syst/"
+	},
+	"wot-geolocation-proposal": {
+	  title: "WoT Discovery - Geolocation",
+	  status: "Proposal",
+	  date: "8 March 2021",
+	  authors: [
+	    "Michael McCool"
+	  ],
+          href: "https://github.com/w3c/wot-discovery/blob/main/proposals/geolocation.md"
 	}
       }
     };
@@ -2438,11 +2447,9 @@
           <dd>
 
             <ul>
-              <li><a href="https://www.w3.org/TR/wot-thing-description/">Web of Things Thing Description (WoT TD)</a>
-              </li>
-              <li><a href="https://w3c.github.io/wot-binding-templates/">Web of Things Binding Templates</a></li>
-              <li><a href="https://github.com/w3c/wot-discovery/blob/main/proposals/geolocation.md">WoT Discovery and
-                  Geolocation</a></li>
+              <li>Web of Things (WoT) Thing Description (TD) [[wot-thing-description]]</li>
+              <li>Web of Things (WoT) Binding Templates [[wot-binding-templates]]</li>
+              <li>WoT Discovery - Geolocation (Proposal) [[wot-geolocation-proposal]]</li>
             </ul>
 
           </dd>
@@ -2816,7 +2823,7 @@
           <dd>
 
             <ul>
-              <li><a href="https://www.w3.org/TR/wot-thing-description/">Web of Things Thing Description (WoT TD)</a>
+              <li>Web of Things (WoT) Thing Description (TD) [[wot-thing-description]]</a>
               </li>
             </ul>
 
@@ -2984,7 +2991,7 @@
               <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</a></li>
               <li>SAREF4BLDG ETSI Standard [[SAREF4BLDG]]</li>
               <li>SAREF4SYST ETSI Standard [[SAREF4SYST]]</li>
-              <li><a href="https://www.w3.org/TR/wot-thing-description/">Web of Things</a></li>
+              <li>Web of Things (WoT) Thing Description (TD) [[wot-thing-description]]</li>
             </ul>
 
           </dd>

--- a/index.html
+++ b/index.html
@@ -154,24 +154,16 @@
           href: "http://www.bacnet.org",
           publisher: "ASHRAE"
         },
-        "CoAP": {
-          title: "The Constrained Application Protocol (CoAP)",
-          href: "https://tools.ietf.org/html/rfc7252",
-          authors: [
-            "Z. Shelby",
-            "K. Hartke",
-            "C. Bormann"
-          ],
-          status: "Published",
-          date: "June 2014",
-          publisher: "IETF"
-        },
         "IEC 61850": {
-          title: "IEC 61850",
-          publisher: "IEC"
+          title: "IEC 61850:2022 - Communication networks and systems for power utility automation",
+	  date: "4 January 2022",
+	  href: "https://webstore.iec.ch/publication/6028",
+          publisher: "IEC TC 57"
         },
-        "IEEE 1574": {
-          title: "IEEE 1574",
+        "IEEE 1547": {
+          title: "IEEE 1547-2018 - Interconnection and Interoperability of Distributed Energy Resources with Associated Electric Power Systems Interfaces",
+	  date: "15 February 2018",
+	  href: "https://standards.ieee.org/standard/1547-2018.html",
           publisher: "IEEE"
         },
         "KNX": {
@@ -187,6 +179,7 @@
         "OGC Sensor Things": {
           title: "OGC Sensor Things API",
           href: "https://www.ogc.org/standards/sensorthings",
+	  date: "4 August 2021",
           publisher: "Open Geospatial Consortium"
         },
         "OneM2M": {
@@ -705,11 +698,11 @@
           <dt>Existing Standards</dt>
           <dd>
             <ul>
-              <li><a href="https://tools.ietf.org/html/rfc8376">LPWAN</a></li>
+              <li>LPWAN [[rfc8376]]</li>
               <li><a href="http://www.sdi-12.org/current_specification/SDI-12_version-1_4-Jan-10-2019.pdf">SDI 12</a>
               </li>
-              <li><a href="https://tools.ietf.org/html/rfc7252">CoAP</a></li>
-              <li><a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html">MQTT</a></li>
+              <li>CoAP [[rfc7252]]</li>
+              <li>MQTT [[MQTT]]</li>
             </ul>
           </dd>
           <dt>Comments</dt>
@@ -2123,7 +2116,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            BACnet, KNX, OPC-UA, Modbus
+            BACnet [[BACnet]], KNX [[KNX]], OPC UA [[OPC UA]], Modbus [[Modbus]]
 
           </dd>
           <!--dt>Comments</dt>
@@ -2243,7 +2236,7 @@
           <dd>
 
             <ul>
-              <li><a href="https://www.ogc.org/standards/sensorthings">OGC SensorThings</a> model includes a
+              <li>OGC Sensor Things [[OGC Sensor Things]] model includes a
                 `properties` property for each Thing which is a non-normative JSON Object for application-specific
                 information (not to be confused with TD's `properties` which is a Map of instances of PropertyAffordance
               </li>
@@ -3057,9 +3050,9 @@
             and web forecasting services like traffic and weather forecasts are expected to be integrated directly into
             the manufacturing process as well as in the product lifecycle. To realize cross-domain applications for the
             Industrie 4.0 context, a frequent exchange with suppliers or local infrastructure providers (e.g., power
-            supplier) is needed and it is necessary to interact with manufacturing systems that usally offers an OPC-UA
+            supplier) is needed and it is necessary to interact with manufacturing systems that usally offers an OPC UA [[OPC UA]]
             interface. WoT can act as a common and standardized application layer and can be used to support Industry 4.0
-            use cases. In this context, well-formed bindings for most established industry standards such as OPC-UA should
+            use cases. In this context, well-formed bindings for most established industry standards such as OPC UA should
             be supported.
           </dd>
           <dt>Expected Devices</dt>
@@ -3069,16 +3062,16 @@
           </dd>
           <dt>Dependencies - Affected WoT deliverables and/or work items</dt>
           <dd>
-            There are some experiences of OPC-UA bindings in previous WoT PlugFests and there is a sample binding
+            There are some experiences of OPC UA bindings in previous WoT PlugFests and there is a sample binding
             implementation in <a href="https://github.com/eclipse/thingweb.node-wot/">node-wot</a>. However, there needs
-            to be a formal definition to map the interaction affordances of a TD to OPC-UA. In that context an official
-            OPC-UA Binding Note document schould be developed that can be used as official reference to design Thing
-            Descriptions for OPC-UA use cases.
+            to be a formal definition to map the interaction affordances of a TD to OPC UA. In that context an official
+            OPC UA Binding Note document schould be developed that can be used as official reference to design Thing
+            Descriptions for OPC UA use cases.
           </dd>
           <dt>Description</dt>
           <dd>
             A bottling line consists of a filling module (switchable between 2 fillers and 4 fillers), a capping module, a
-            labeling module, and a transport system. The production line is provided via an OPC-UA endpoint for control
+            labeling module, and a transport system. The production line is provided via an OPC UA endpoint for control
             and monitoring purposes.
             <div class="resize"><img src="images/industry-4.0.png" alt="Bottling Line Example"></div>
             In the context of enhancing productivity and sustainability, the goal is to operate the bottling line in such
@@ -3087,21 +3080,21 @@
             and how much renewable energy is produced.
             Based on the bottling line's current power consumption, which is measured via Modbus, the backend system
             decides to increase productivity when surplus renewable energy is available.
-            In doing so, the backend system interacts via OPC-UA to release the 4 fillers of the filling module and
+            In doing so, the backend system interacts via OPC UA to release the 4 fillers of the filling module and
             increases the speed of the transport system.
             If the backend system detects that less renewable energy is being produced, it will initiate standard
             production and reduce the transport speed and return the 2 fillers of the filling module.
           </dd>
           <dt>Security Considerations</dt>
           <dd>
-            OPC-UA has different security modes (sign and/or encrypted, policies, and authentication). Those should be
+            OPC UA has different security modes (sign and/or encrypted, policies, and authentication). Those should be
             addressed and described in Thing Descriptions with a standardized vocabulary definition. Additional security
             considerations may apply if a web bridge is created using WoT servients. OT networks are often isolated and
-            OPC-UA may have special requirements for distribution of key materials and credentials.
+            OPC UA may have special requirements for distribution of key materials and credentials.
           </dd>
           <dt>Privacy Considerations</dt>
           <dd>
-            OPC-UA comes with different approaches to protect data (also see Security Considerations above).
+            OPC UA comes with different approaches to protect data (also see Security Considerations above).
           </dd>
           <dt>Accessibility Considerations</dt>
           <dd>
@@ -3114,7 +3107,7 @@
           </dd>
           <dt>Requirements</dt>
           <dd>
-            An OPC UA binding for Web of Things needs an own set of OPC-UA specific vocabulary definitions which should be
+            An OPC UA binding for Web of Things needs an own set of OPC UA specific vocabulary definitions which should be
             developed together with the experts from the OPC Foundation. Also see the <a
               href="https://opcfoundation.org/news/opc-foundation-news/w3c-and-opcf-to-integrate-opc-ua-into-the-web-of-things/">liaison</a>.
           </dd>
@@ -5052,10 +5045,9 @@
       </dd-->
           <dt>Existing Standards</dt>
           <dd>
-
-            IEC 61850 - International standard for data models and communication protocols
-            <br>
-            IEEE 1547 - US standard for interconnecting distributed resources with electric power systems
+            <ul>
+	    <li>IEC 61850 - International standard for data models and communication protocols [[IEC 61850]]</li>
+	    <li>IEEE 1547 - US standard for interconnecting distributed resources with electric power systems [[IEEE 1547]]</li>
 
           </dd>
           <!--dt>Comments</dt>
@@ -6508,7 +6500,7 @@
           </p>
           <p>
             In an industrial environment individual actuators and production devices use different protocols.
-            Examples include MQTT, OPC-UA, Modbus, Fieldbus, and others.
+            Examples include MQTT [[MQTT]], OPC UA [[OPC UA]], Modbus [[Modbus]], Fieldbus, and others.
             Gathering data from these devices, e.g. to support digital twins or big data use cases requires an "Agent"
             to bridge across these protocols.
             To provide interoperability and to reduce implementation complexity of this agent a common set of (minimum
@@ -6534,7 +6526,7 @@
         <dt>Existing Standards</dt>
         <dd>
 
-          MQTT, OPC-UA, BACNet, CoAP, various other home and industrial protocols.
+          MQTT [[MQTT]], OPC-UA [OPC UA], BACNet [[BACnet]], CoAP [[rfc7252]], various other home and industrial protocols.
         </dd>
         <!--dt>Comments</dt>
           <dd>
@@ -8483,7 +8475,7 @@
     <section id="opc-foundation">
       <h2>OPC Foundation</h2>
       <p>
-        OPC UA is one of the important automation standards for device communication
+        OPC UA [[OPC UA]]  is one of the important automation standards for device communication
         in the factory domain as well as for Industry 4.0 scenarios such as like
         flexible manufacturing.
       </p>
@@ -8596,6 +8588,20 @@
       [[OGC]]
       [[OGC-coords]]
       [[iso-19111-2019]
+      [[IEC 61850]]
+      [[IEEE 1547]]
+      [[OGC Sensor Things]]
+      [[OPC UA]]
+      [[MQTT]]
+      [[BACnet]]
+      [[KNX]]
+      [[Modbus]]
+      [[ICE F2761-09(2013)]]
+      [[OpenICE]]
+      [[MDIRA]]
+      [[OneM2M]] <!-- Many, many citations of specific specs in specref; but this is for the ORG -->
+      [[LWM2M]] <!-- only ref in specref is for interop with OneM2M; this is for the org -->
+      [[OCF]]
 
      <!-- and some references that ARE in the specref database, and we should cite, but are not currently cited -->
       [[json-schema]]
@@ -8606,23 +8612,8 @@
       [[geolocation-API]]
       [[iso-19111-2007]
       [[hr-time-3]] <!-- replaces [Timestamps] -->
-
-     <!-- the following MAY be in specref -->
-      [ICE F2761-09(2013)]
-      [OpenICE]
-      [MDIRA]
-      [MQTT]
-      [OPC UA]
-      [BACnet]
-      [CoAP]
-      [IEC 61850]
-      [IEEE 1574]
-      [KNX]
-      [Modbus]
-      [OGC Sensor Things]
-      [OneM2M]
-      [LWM2M]
-      [OCF]
+      [[rfc7252]] <!-- replaces [CoAP] -->
+      [[rfc8376]] <!-- LPWAN -->
     </p>
 
 

--- a/index.html
+++ b/index.html
@@ -124,6 +124,18 @@
           href: "https://brickschema.org/",
 	  publisher: "The Brick Consortium, Inc."
 	},
+	"BOT": {
+	  authors: [
+	    "Mads Holten Rasmussen",
+	    "Pieter Pauwels",
+	    "Maxime Lefrançois",
+	    "Georg Ferdinand Schneider"
+	  ],
+	  title: "Building Topology Ontology",
+	  href: "https://w3c-lbd-cg.github.io/bot/index.html",
+	  publisher: "W3C Linked Building Data Community Group",
+	  date: "28 June 2021"
+	}
         "ISO19111": {
           title: "ISO19111",
           href: "https://www.iso.org/standard/74039.html",
@@ -2900,7 +2912,7 @@
 
             Accessibility is a major concern in the buildings domain. Efforts exist in also providing accessibility data
             in a electronic format. The W3C LBD CG is in contact with the <a
-              href="https://www.w3.org/community/lda/">W3C Linked Data for Accessbility Community Group</a>.
+              href="https://www.w3.org/community/lda/">W3C Linked Data for Accessibility Community Group</a>.
 
           </dd>
           <dt>Internationalisation (i18n) Considerations</dt>
@@ -2943,7 +2955,7 @@
 
             <ul>
               <li>Brick Schema [[Brick]]</li>
-              <li><a href="https://w3c-lbd-cg.github.io/bot/index.html">BOT</a></li>
+              <li>Building Topology Ontology (BOT) [[BOT]]</li>
               <li><a href="https://www.w3.org/TR/vocab-ssn/">SSN/SOSA</a></li>
               <li><a href="https://saref.etsi.org/saref4bldg/v1.1.2/">SAREF4BLDG</a></li>
               <li><a href="https://saref.etsi.org/saref4syst/">SAREF4SYST</a></li>

--- a/index.html
+++ b/index.html
@@ -124,30 +124,6 @@
           date: "Jan 2019",
           publisher: "ISO"
         },
-        "Timestamps": {
-          title: "Timestamps",
-          href: "https://w3c.github.io/hr-time/#dom-domhighrestimestamp",
-          authors: ["Ilya Grigorik"],
-          status: "Draft",
-          date: "06 Oct 2020",
-          publisher: "W3C"
-        },
-        "MMI UC3.1": {
-          title: "MMI UC3.1",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
-        "MMI UC3.2": {
-          title: "MMI UC3.2",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
         "ICE F2761-09(2013)": {
           title: "ICE F2761-09(2013)",
           publisher: "IEC"
@@ -189,46 +165,6 @@
           status: "Published",
           date: "June 2014",
           publisher: "IETF"
-        },
-        "MMI UC5.1": {
-          title: "MMI UC5.1",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
-        "MMI UC5.2": {
-          title: "MMI UC5.2",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
-        "MMI UC1.1": {
-          title: "MMI UC1.1",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
-        "MMI UC1.2": {
-          title: "MMI UC1.2",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
-        },
-        "MMI UC2.1": {
-          title: "MMI UC2.1",
-          href: "https://www.w3.org/TR/mmi-use-cases/",
-          authors: ["Emily Candell, Dave Raggett"],
-          status: "published",
-          date: "2002",
-          publisher: "W3C"
         },
         "IEC 61850": {
           title: "IEC 61850",
@@ -1306,9 +1242,7 @@
               </li>
               <li>Timestamps:
                 <ul>
-                  <li>W3C standard in proposed new web geolocation API: <a
-                      href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a>
-                  </li>
+                  <li>W3C High Resolution Time [[hr-time-3]] </li>
                   <li>See also related issues such as latency defined in SSN</li>
                 </ul>
               </li>
@@ -1574,7 +1508,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 3.1.
+            This use case is based on MMI UC 3.1 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -1673,7 +1607,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 3.2.
+            This use case is based on MMI UC 3.2 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -4774,7 +4708,7 @@
             <dt>Existing Standards</dt>
             <dd>
 
-              This use case is based on MMI UC 3.2.
+              This use case is based on MMI UC 3.2 [[mmi-use-cases]].
 
             </dd>
             <dt>Comments</dt>
@@ -5359,7 +5293,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 2.1.
+            This use case is based on MMI UC 2.1 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -6692,7 +6626,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 5.1.
+            This use case is based on MMI UC 5.1 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -6803,7 +6737,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 5.2.
+            This use case is based on MMI UC 5.2 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -6946,7 +6880,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 1.1.
+            This use case is based on MMI UC 1.1 [[mmi-use-cases]].
 
           </dd>
           <dt>Comments</dt>
@@ -7060,7 +6994,7 @@
           <dt>Existing Standards</dt>
           <dd>
 
-            This use case is based on MMI UC 1.2; original title was Intelligent Home Apparatus.
+            This use case is based on MMI UC 1.2 [[mmi-use-cases]]; original title was Intelligent Home Apparatus.
 
           </dd>
           <dt>Comments</dt>
@@ -8671,11 +8605,9 @@
       [[w3c-basic-geo]
       [[geolocation-API]]
       [[iso-19111-2007]
+      [[hr-time-3]] <!-- replaces [Timestamps] -->
 
      <!-- the following MAY be in specref -->
-      [Timestamps]
-      [MMI UC3.1]
-      [MMI UC3.2]
       [ICE F2761-09(2013)]
       [OpenICE]
       [MDIRA]
@@ -8683,11 +8615,6 @@
       [OPC UA]
       [BACnet]
       [CoAP]
-      [MMI UC5.1]
-      [MMI UC5.2]
-      [MMI UC1.1]
-      [MMI UC1.2]
-      [MMI UC2.1]
       [IEC 61850]
       [IEEE 1574]
       [KNX]

--- a/index.html
+++ b/index.html
@@ -143,21 +143,6 @@
           date: "Jan 2019",
           publisher: "ISO"
         },
-        "SSN": {
-          title: "Semantic Sensor Network Ontology",
-          href: "https://www.w3.org/TR/vocab-ssn/",
-          authors: [
-            "Armin Haller",
-            "Krzysztof Janowicz",
-            "Simon Cox",
-            "Danh Le Phuoc",
-            "Kerry Taylor",
-            "Maxime Lefrançois"
-          ],
-          status: "Published",
-          date: "19 Oct 2017",
-          publisher: "W3C"
-        },
         "Timestamps": {
           title: "Timestamps",
           href: "https://w3c.github.io/hr-time/#dom-domhighrestimestamp",
@@ -976,7 +961,7 @@
           <dd>
 
             <ul>
-              <li><a href="https://www.w3.org/TR/vocab-ssn/">Semantic Sensor Network</a></li>
+              <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
               <li><a href="https://saref.etsi.org/saref4agri/v1.1.2/">SAREF4Agri</a></li>
               <li><a href="https://www.w3.org/TR/prov-o/">PROV-O</a></li>
               <li><a
@@ -1031,7 +1016,7 @@
             [4] <a href="http://www.meteofrance.fr/">http://www.meteofrance.fr/</a>
             <br>
             [5] C. ROUSSEY,S. BERNARD, G. ANDRÉ, D. BOFFETY. Weather Data Publication on the LOD using SOSA/SSN
-            Ontology.Semantic Web Journal, 2019 <a
+            Ontology. Semantic Web Journal, 2019 <a
               href="http://www.semantic-web-journal.net/content/weather-data-publication-lod-using-sosassn-ontology-0">http://www.semantic-web-journal.net/content/weather-data-publication-lod-using-sosassn-ontology-0</a>
           </dd>
         </dl>
@@ -1283,7 +1268,7 @@
                   </li>
                 </ul>
               </li>
-              <li><a href="https://www.w3.org/TR/vocab-ssn/">SSN</a>:
+              <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]:
                 <ul>
                   <li>Defines "accuracy": <a
                       href="https://www.w3.org/TR/vocab-ssn/#SSNSYSTEMAccuracy">https://www.w3.org/TR/vocab-ssn/#SSNSYSTEMAccuracy</a>
@@ -2082,7 +2067,7 @@
             <ul>
               <li><a href="https://saref.etsi.org/saref4ener/">SAREF4ENER ETSI Standard</a></li>
               <li><a href="https://saref.etsi.org/saref4bldg/">SAREF4Bldg ETSI Standard</a></li>
-              <li><a href="https://www.w3.org/TR/vocab-ssn/">SOSA/SSN W3C Recommendation</a></li>
+              <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
             </ul>
 
           </dd>
@@ -2692,7 +2677,7 @@
           <dd>
             <ul>
               <li><a href="https://saref.etsi.org/saref4bldg/">SAREF4Bldg an ETSI Standard</a></li>
-              <li><a href="https://www.w3.org/TR/vocab-ssn/">SOSA/SSN a W3C Recommendation</a></li>
+              <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
               <li><a href="https://standards.buildingsmart.org/IFC/DEV/IFC4/ADD2/OWL/index.html">Industry Foundation
                   Classes (IFC) an
                   ISO standard</a></li>
@@ -2956,7 +2941,7 @@
             <ul>
               <li>Brick Schema [[Brick]]</li>
               <li>Building Topology Ontology (BOT) [[BOT]]</li>
-              <li><a href="https://www.w3.org/TR/vocab-ssn/">SSN/SOSA</a></li>
+              <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</a></li>
               <li><a href="https://saref.etsi.org/saref4bldg/v1.1.2/">SAREF4BLDG</a></li>
               <li><a href="https://saref.etsi.org/saref4syst/">SAREF4SYST</a></li>
               <li><a href="https://www.w3.org/TR/wot-thing-description/">Web of Things</a></li>

--- a/index.html
+++ b/index.html
@@ -67,14 +67,6 @@
           }]
         }],
       localBiblio: {
-        "JSON-SCHEMA": {
-          title: "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
-          href: "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
-          authors: ["Austin Wright", "Henry Andrews", "Geraint Luff"],
-          status: "Internet-Draft",
-          date: "19 March 2018",
-          publisher: "IETF"
-        },
         "ISO-6709": {
           title: "ISO-6709:2008 : Standard representation of geographic point location by coordinates",
           href: "https://www.iso.org/standard/39242.html",
@@ -83,41 +75,30 @@
           publisher: "ISO"
         },
         "Hybridcast": {
-          title: "Hybridcast",
-          href: "...",
-          authors: ["..."],
-          status: "...",
-          date: "..",
-          publisher: "..."
+          title: "IPTVFJ STD-0013 Hybridcast Operational Guideline Version 2.8",
+          href: "https://www.iptvforum.jp/en/hybridcast/specification.html",
+          date: "19 September 2020",
+          publisher: "IPTVFJ"
         },
-        "NMEA": {
-          title: "National Marine Electronics Association",
-          href: "https://www.nmea.org"
+        "NMEA-0183": {
+	  title: "NMEA 0183 Interface Standard",
+          publisher: "National Marine Electronics Association",
+	  date: "November 2018",
+          href: "https://www.nmea.org/content/STANDARDS/NMEA_0183_Standard"
         },
         "EDGEX": {
           title: "EdgeX Foundry",
           href: "https://www.edgexfoundry.org/"
         },
-        "WGS84": {
-          title: "WGS84",
-          href: "https://en.wikipedia.org/wiki/World_Geodetic_System",
-        },
-        "Basic Geo Vocabulary": {
-          title: "W3C Semantic Web Interest Group",
-          href: "https://www.w3.org/2003/01/geo/",
-          publisher: "W3C"
-        },
-        "W3C Geolocalization API": {
-          title: "Geolocation API Specification 2nd Edition",
-          href: "https://www.w3.org/TR/geolocation-API/",
-          authors: ["Andrei Popescu"],
-          status: "Published",
-          date: "8 Nov 2016",
-          publisher: "W3C"
-        },
-        "Open Geospatial Consortium": {
+        "OGC": {
           title: "Open Geospatial Consortium",
-          href: "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html"
+          href: "https://www.ogc.org/"
+        },
+        "OGC-coords": {
+          title: "OGC Abstract Specification Topic 2: Referencing by coordinates",
+          href: "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html",
+	  date: "8 February 2019",
+	  publisher: "Open Geospatial Consortium"
         },
         "Brick": {
 	  title: "Brick Schema",
@@ -136,8 +117,8 @@
 	  publisher: "W3C Linked Building Data Community Group",
 	  date: "28 June 2021"
 	},
-        "ISO19111": {
-          title: "ISO19111",
+        "iso-19111-2019": {
+          title: "ISOi 19111:2019 - Geographic information — Referencing by coordinates",
           href: "https://www.iso.org/standard/74039.html",
           status: "Published",
           date: "Jan 2019",
@@ -1171,7 +1152,7 @@
               </li>
               <li>For each geolocation technology, data specific to that technology:
                 <ul>
-                  <li>GPS: NMEA type</li>
+                  <li>GPS: NMEA type [[NMEA-0183]]</li>
                 </ul>
               </li>
               <li>Historical data</li>
@@ -1261,16 +1242,15 @@
           <dd>
             <p>
             <ul>
-              <li>NMEA: defines sentences from GPS devices</li>
-              <li><a href="https://en.wikipedia.org/wiki/World_Geodetic_System">WGS84</a>:
+              <li>NMEA: defines sentences from GPS devices [[NMEA-0183]]</li>
+              <li>World Geodetic System (WGS84) [[WGS84]]:
                 <ul>
-                  <li>World Geodetic System</li>
                   <li>Defines lat/long/alt coordinate system used by most other geolocation standards</li>
                   <li>More complicated than you would think (need to deal with deviations of Earth from
                     a true sphere, gravitational irregularities, position of centroid, etc. etc.)</li>
                 </ul>
               </li>
-              <li><a href="https://www.w3.org/2003/01/geo/">Basic Geo Vocabulary</a>:
+              <li>Basic Geo Vocabulary [[w3c-basic-geo]]:
                 <ul>
                   <li>Very basic RDF definitions for lat, long, and alt</li>
                   <li>Does not define heading or speed</li>
@@ -1279,7 +1259,7 @@
                   <li>Uses string as a data model (rather than a number)</li>
                 </ul>
               </li>
-              <li><a href="https://www.w3.org/TR/geolocation-API/">W3C Geolocalization API</a>:
+              <li>W3C Geolocation API [[geolocation-API]]:
                 <ul>
                   <li>W3C Devices and Sensors WG is now handling</li>
                   <li>There is an updated proposal: <a
@@ -1294,11 +1274,9 @@
                   </li>
                 </ul>
               </li>
-              <li><a href="https://www.ogc.org/">Open Geospatial Consortium</a>:
+              <li>Open Geospatial Consortium [[OGC]]</a>:
                 <ul>
-                  <li>See <a
-                      href="http://docs.opengeospatial.org/as/18-005r4/18-005r4.html">http://docs.opengeospatial.org/as/18-005r4/18-005r4.html</a>
-                  </li>
+                  <li>See OGC Abstract Specification Topic 2: Referencing by coordinates [[OGC-coords]]</li>
                   <li>Referring to locations by coordinates</li>
                   <li>Has standards defining semantics for identifying locations</li>
                   <li>Useful for mapping</li>
@@ -1306,7 +1284,7 @@
               </li>
               <li>ISO:
                 <ul>
-                  <li><a href="https://www.iso.org/standard/74039.html">ISO19111</a>:</li>
+                  <li>ISO 19111 [[iso-19111-2007]], [[iso-19111-2019]]</li>
                   <ul>
                     <li>Standard for referring to locations by coordinates</li>
                     <li>Related to OGS standard above and WGS84</li>
@@ -5482,15 +5460,13 @@
             <section id="todo-gaps-1" class="ednote">
               TODO: Provide links to relevant standards that are relevant for this use case</section>
 
-          </dd>
+	      </dd>
           <dt>Existing Standards & related information</dt>
           <dd>
-
-            <section id="todo-references-x" class="ednote">TODO: Provide links to relevant standards that are
-              relevant for this use case.
-              <p>There are MANY TV standards and this would be a long list. Rather leave blank unless a very specific
-                standard provides more insight.</p>
-            </section>
+	    <ul>
+		    <li>Hybridcast [[Hybridcast]]</li>
+                    <li>... and many other TV standards, including additional Hybridcast standards cited from the above reference.</li>
+            </ul>
 
           </dd>
           <dt>Comments</dt>
@@ -5588,7 +5564,7 @@
               (Hybridcast is a Japanese Integrated Broadcast-Broadband system. Hybridcast applications are HTML5
               applications that work on Hybridcast TV.)
             </p>
-            <p>Hybridcast Contact application receives the information and controlls smart home devices.</p>
+            <p>Hybridcast Contact application receives the information and controls smart home devices.</p>
             <div class="resize"><img src="images/scenario_nhk.png" alt="Hybridcast Connect Application"></div>
           </dd>
           <!--dt>Variants</dt>
@@ -5596,16 +5572,17 @@
 
           </dd>
           <dt>Gaps</dt>
-          <dd->
+          <dd-->
 
           </dd>
           <dt>Existing Standards</dt>
           <dd>
 
-            Hybridcast and Hybridcast Connect: a Japanese Integrated Broadcast-Broadband system (<a href="http://www.iptvforum.jp/download/input.html">IPTVFJ STD-0013 "Hybridcast Operational Guideline Version 2.8" (Application Forms)</a>, <a href="https://github.com/nhkrd">Reference Implementations</a>),
+            Hybridcast and Hybridcast Connect: a Japanese Integrated Broadcast-Broadband system [[Hybridcast]], 
+	    <a href="https://github.com/nhkrd">Reference Implementations</a>),
             HbbTV,
             ATSC 3.0,
-            ...etc.
+            etc.
 
           </dd>
           <dt>Comments</dt>
@@ -5613,7 +5590,6 @@
 
           </dd>
         </dl>
-      </section-->
 
       </section>
 
@@ -8677,19 +8653,26 @@
   </section>
 
     <p style="display: none;">
-      <!-- This is a hack to make sure the local references are included in the informative reference section 
-    The proper solution is to replace the occurences with the proper Specref ids.
-    This should be done for the next published version -->
-      [JSON-SCHEMA]
-      [ISO-6709]
-      [Hybridcast]
-      [NMEA]
-      [WGS84]
-      [Basic Geo Vocabulary]
-      [W3C Geolocalization API]
-      [Open Geospatial Consortium]
-      [ISO19111]
-      [SSN]
+    <!-- This is a hack to make sure the local references are included in the informative reference section -->
+
+    <!-- The following are local references and do not seem to exist in the specref database -->
+      [[ISO-6709]]
+      [[Hybridcast]]
+      [[NMEA-0183]]
+      [[OGC]]
+      [[OGC-coords]]
+      [[iso-19111-2019]
+
+     <!-- and some references that ARE in the specref database, and we should cite, but are not currently cited -->
+      [[json-schema]]
+
+     <!-- These are cited, and are in specref, but to be sure, including them here anyway -->
+      [[WGS84]]
+      [[w3c-basic-geo]
+      [[geolocation-API]]
+      [[iso-19111-2007]
+
+     <!-- the following MAY be in specref -->
       [Timestamps]
       [MMI UC3.1]
       [MMI UC3.2]

--- a/index.html
+++ b/index.html
@@ -117,8 +117,13 @@
         },
         "Open Geospatial Consortium": {
           title: "Open Geospatial Consortium",
-          href: "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html",
+          href: "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html"
         },
+        "Brick": {
+	  title: "Brick Schema",
+          href: "https://brickschema.org/",
+	  publisher: "The Brick Consortium, Inc."
+	},
         "ISO19111": {
           title: "ISO19111",
           href: "https://www.iso.org/standard/74039.html",
@@ -2540,8 +2545,8 @@
             be used to automatically commission the newly replaced sensor and link it to existing control
             algorithms. For this purpose, the identifiers of suitable sensors and actuators are needed and can be,
             for example, queried via <a href="https://www.w3.org/TR/sparql11-query/">SPARQL</a>. Here the query uses
-            some additional classification of sensors from <a href="https://brickschema.org/ontology/1.1">BRICK
-              schema</a>.</p>
+            some additional classification of sensors from the Brick
+              schema, v1.1 [[Brick]].</p>
 
           <pre class="example" id="sparql">
                             <code class="lang-sparql">PREFIX <span class="hljs-string">bot:</span> &lt;<span class="hljs-string">https:</span><span class="hljs-comment">//w3id.org/bot&gt;</span>
@@ -2680,7 +2685,7 @@
                   Classes (IFC) an
                   ISO standard</a></li>
               <li><a href="https://w3id.org/bot">Building Topology Ontology (BOT)</a></li>
-              <li><a href="https://brickschema.org">BRICK</a></li>
+              <li>Brick Schema [[Brick]]</li>
             </ul>
 
           </dd>
@@ -2912,7 +2917,7 @@
           <dd>
 
             <ul>
-              <li>Integration with Brick Ontology: Brick has not yet decided on how the values coming out of devices,
+              <li>Integration with Brick Ontology [[Brick]]: Brick has not yet decided on how the values coming out of devices,
                 sensors, etc. should be represented. WoT has the potential to fulfill that role.</li>
             </ul>
 
@@ -2937,7 +2942,7 @@
           <dd>
 
             <ul>
-              <li><a href="https://brickschema.org/">Brick</a></li>
+              <li>Brick Schema [[Brick]]</li>
               <li><a href="https://w3c-lbd-cg.github.io/bot/index.html">BOT</a></li>
               <li><a href="https://www.w3.org/TR/vocab-ssn/">SSN/SOSA</a></li>
               <li><a href="https://saref.etsi.org/saref4bldg/v1.1.2/">SAREF4BLDG</a></li>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 	  href: "https://w3c-lbd-cg.github.io/bot/index.html",
 	  publisher: "W3C Linked Building Data Community Group",
 	  date: "28 June 2021"
-	}
+	},
         "ISO19111": {
           title: "ISO19111",
           href: "https://www.iso.org/standard/74039.html",

--- a/index.html
+++ b/index.html
@@ -295,6 +295,46 @@
           date: "April 2019",
           publisher: "ECLASS e.V."
         },
+        "SAREF4AGRI": {
+	  title: "SAREF4AGRI: an extension of SAREF for the agriculture and food domain",
+	  authors: [
+	    "Maria Poveda-Villalon",
+            "Raúl Garcia-Castro",
+            "Laura Daniele",
+            "Mike de Roode"
+	  ],
+	  date: "30 April 2019",
+	  publisher: "ETSI",
+	  href: "https://saref.etsi.org/saref4agri/"
+	},
+        "SAREF4ENER": {
+	  title: "SAREF4ENER: an extension of SAREF for the energy domain created in collaboration with Energy@Home and EEBus associations",
+	  authors: [
+            "Laura Daniele"
+	  ],
+	  date: "4 June 2020",
+	  publisher: "ETSI",
+	  href: "https://saref.etsi.org/saref4ener/"
+	},
+        "SAREF4BLDG": {
+	  title: "SAREF extension for building",
+	  authors: [
+	    "María Poveda-Villalón",
+            "Raúl Garcia-Castro"
+	  ],
+	  date: "13 April 2020",
+	  publisher: "ETSI",
+	  href: "https://saref.etsi.org/saref4bldg/"
+	},
+        "SAREF4SYST": {
+	  title: "SAREF4SYST: an extension of SAREF for typology of systems and their inter-connections",
+	  authors: [
+            "Maxime Lefrançois"
+	  ],
+	  date: "6 June 2019",
+	  publisher: "ETSI",
+	  href: "https://saref.etsi.org/saref4syst/"
+	}
       }
     };
   </script>
@@ -962,7 +1002,7 @@
 
             <ul>
               <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
-              <li><a href="https://saref.etsi.org/saref4agri/v1.1.2/">SAREF4Agri</a></li>
+              <li>SAREF4AGRI ETSI Standard [[SAREF4AGRI]]</li>
               <li><a href="https://www.w3.org/TR/prov-o/">PROV-O</a></li>
               <li><a
                   href="https://irstea.github.io/caso/OnToology/ontology/caso.owl/documentation/index-en.html">CASO</a>
@@ -2065,8 +2105,8 @@
           <dd>
 
             <ul>
-              <li><a href="https://saref.etsi.org/saref4ener/">SAREF4ENER ETSI Standard</a></li>
-              <li><a href="https://saref.etsi.org/saref4bldg/">SAREF4Bldg ETSI Standard</a></li>
+              <li>SAREF4ENER ETSI Standard [[SAREF4ENER]]</li>
+              <li>SAREF4BLDG ETSI Standard [[SAREF4BLDG]]</a></li>
               <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
             </ul>
 
@@ -2676,7 +2716,7 @@
           <dt>Existing Standards</dt>
           <dd>
             <ul>
-              <li><a href="https://saref.etsi.org/saref4bldg/">SAREF4Bldg an ETSI Standard</a></li>
+              <li>SAREF4BLDG ETSI Standard [[SAREF4BLDG]]</li>
               <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</li>
               <li><a href="https://standards.buildingsmart.org/IFC/DEV/IFC4/ADD2/OWL/index.html">Industry Foundation
                   Classes (IFC) an
@@ -2942,8 +2982,8 @@
               <li>Brick Schema [[Brick]]</li>
               <li>Building Topology Ontology (BOT) [[BOT]]</li>
               <li>Semantic Sensor Network Ontology (SSN/SOSA) [[vocab-ssn]]</a></li>
-              <li><a href="https://saref.etsi.org/saref4bldg/v1.1.2/">SAREF4BLDG</a></li>
-              <li><a href="https://saref.etsi.org/saref4syst/">SAREF4SYST</a></li>
+              <li>SAREF4BLDG ETSI Standard [[SAREF4BLDG]]</li>
+              <li>SAREF4SYST ETSI Standard [[SAREF4SYST]]</li>
               <li><a href="https://www.w3.org/TR/wot-thing-description/">Web of Things</a></li>
             </ul>
 

--- a/index.html
+++ b/index.html
@@ -2995,11 +2995,11 @@
             </ul>
 
           </dd>
-          <dt>Comments</dt>
+          <!--dt>Comments</dt>
           <dd>
 
 
-          </dd>
+          </dd -->
         </dl>
       </section>
     </section>


### PR DESCRIPTION
Clean up references to use specref database references when possible (searching using https://www.specref.org/).  In the long run we should try to add local references to the specref database.

* Resolve #135 
* Resolve #121

Note: there are still direct hyperlinks remaining in the text for various reasons.  I have left some alone if I think they were appropriate: they refer to an organization's website e.g. for a CG; they are embedded in example SPARQL queries, etc.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-usecases/pull/177.html" title="Last updated on Jan 25, 2022, 4:59 AM UTC (2e416bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/177/4b02533...mmccool:2e416bd.html" title="Last updated on Jan 25, 2022, 4:59 AM UTC (2e416bd)">Diff</a>