### PR TITLE
Update README-coverage.md

### DIFF
--- a/USE-CASES/README-coverage.md
+++ b/USE-CASES/README-coverage.md
@@ -9,7 +9,6 @@ Please use the following conventions:
 
 * Use N/A, if the requirement does not affect the deliverable in the column.
 * Use the comment column to describe open issues, questions.
-* Use "-" if there is no gap on your deliverable.
+* Use "-" if there is no gap with respect to the deliverable in the column. Difference from the `N/A` is that this use case is implementable with the deliverable and is relevant for the deliverable.
 * Write the idenfitied gap, e.g. "hint for UI", if there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
 * Do not use "," to separate entries in a single column, use "/" instead.
-

--- a/USE-CASES/README-coverage.md
+++ b/USE-CASES/README-coverage.md
@@ -10,6 +10,6 @@ Please use the following conventions:
 * Use N/A, if the requirement does not affect y deliverable.
 * Use the comment column to describe open issues, questions.
 * Use "-" if there is no gap on your deliverable.
-* Use "gap" to mark that there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
+* Write the idenfitied gap, e.g. "hint for UI", if there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
 * Do not use "," to separate entries in a single column, use "/" instead.
 

--- a/USE-CASES/README-coverage.md
+++ b/USE-CASES/README-coverage.md
@@ -1,4 +1,4 @@
-The coverade.csv file is intended to identify specification gaps to drive future standardisation work.
+The [coverage.csv](https://github.com/w3c/wot-usecases/blob/main/USE-CASES/coverage.csv) file is intended to identify specification gaps to drive future standardisation work.
 
 It is the groundwork for new requirements, which will be described in the REQUIREMENTS subdirectory in the corresponding template.
 There will be duplicates in the table, this is expected.
@@ -10,5 +10,6 @@ Please use the following conventions:
 * Use N/A, if the requirement does not affect y deliverable.
 * Use the comment column to describe open issues, questions.
 * Use "-" if there is no gap on your deliverable.
+* Use "gap" to mark that there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
 * Do not use "," to separate entries in a single column, use "/" instead.
 

--- a/USE-CASES/README-coverage.md
+++ b/USE-CASES/README-coverage.md
@@ -7,7 +7,7 @@ The table has some initial contents that can help as examples for some identifie
 
 Please use the following conventions:
 
-* Use N/A, if the requirement does not affect y deliverable.
+* Use N/A, if the requirement does not affect the deliverable in the column.
 * Use the comment column to describe open issues, questions.
 * Use "-" if there is no gap on your deliverable.
 * Write the idenfitied gap, e.g. "hint for UI", if there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.

--- a/USE-CASES/README-coverage.md
+++ b/USE-CASES/README-coverage.md
@@ -10,5 +10,5 @@ Please use the following conventions:
 * Use N/A, if the requirement does not affect the deliverable in the column.
 * Use the comment column to describe open issues, questions.
 * Use "-" if there is no gap with respect to the deliverable in the column. Difference from the `N/A` is that this use case is implementable with the deliverable and is relevant for the deliverable.
-* Write the idenfitied gap, e.g. "hint for UI", if there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
+* Write the identified gap, e.g. "hint for UI", if there is a gap with that deliverable. In this case, create an issue in the corresponding deliverable. In that issue, make sure to use the name of the use case.
 * Do not use "," to separate entries in a single column, use "/" instead.

--- a/USE-CASES/coverage.md
+++ b/USE-CASES/coverage.md
@@ -1,7 +1,0 @@
-# Analysis of spec coverage of use cases
-
-Purpose of the [coverage.csv](./coverage.csv) file is to identify coverage of use cases by the 1.1 versions of the WoT specifications.
-
-All spec editors are requested to assess the coverage of use cases by their specification.
-It is likely that the same gaps and new requirements are identified multiple times for different use cases.
-


### PR DESCRIPTION
There was a typo and I have created a link to the csv file. Some more improvements are in the next comment

I have realized that this file makes https://github.com/w3c/wot-usecases/blob/main/USE-CASES/coverage.md redundant so I propose to delete that one. The other one's name is confusing since one can think that it is the md version of the coverage.csv