### PR TITLE
Remove Business Impact from Requirements Template

### DIFF
--- a/REQUIREMENTS/requirements-template.md
+++ b/REQUIREMENTS/requirements-template.md
@@ -20,10 +20,6 @@
 
 <list all affected deliverables, e.g. TD spec, Profile spec, Scripting API, Security best practices, Discovery, ...>
 
-### Business Justification/Motivation:
- 
-<short description of motivation and business justification>
-
 ### Requirements:
 
 <short description of all requirements>


### PR DESCRIPTION
As agreed on the UC call of 07.02, we remove this section since there is no consensus to where to put this information about justification.