### PR TITLE
Remove statement regarding missing TDD API specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -8928,21 +8928,21 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="CAT-Security-Private-Information">Security Private Information</dt><dd>
 	<p></p>Handles personal or confidential information.
 	<p>Misuse could disclose privately identifiable information (PII) or sensitive business information.
-        Use Cases Included:</p> 
+        Use Cases Included:</p>
 	  <ul>
 	    <li><a href="#UC-smart-cities">Smart Cities</a></li>
 	  </ul>
 	</dd>
 	<dt id="CAT-Security-Safety-Critical">Security Safety Critical</dt><dd>
 	<p>Misuse has the potential to cause personal injury.
-        Use Cases Included:</p> 
+        Use Cases Included:</p>
 	  <ul>
 	    <li><a href="#UC-smart-cities">Smart Cities</a></li>
 	  </ul>
 	</dd>
 	<dt id="CAT-Security-Business-Critical">Security Business Critical</dt><dd>
 	Misuse has the potential to cause financial injury or damage to business operations or reputation.
-        Use Cases Included:</p> 
+        Use Cases Included:</p>
 	  <ul>
 	    <li><a href="#UC-smart-cities">Smart Cities</a></li>
 	  </ul>
@@ -8961,7 +8961,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-PBT">PBT: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-protocol-binding-threat">WoT Protocol Binding Threat</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Private-Information">Security Private Information</a></li>
 	      </ul>
@@ -8971,7 +8971,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-ETC">ETC: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-interface-threat-exposed-thing-compromise">WoT Interface Threat - Exposed Thing Compromise</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Private-Information">Security Private Information</a></li>
 		<li><a href="#CAT-Security-Safety-Critical">Security Safety Critical</a></li>
@@ -8979,11 +8979,11 @@ Therefore, various data for agricultural machinery management should be represen
 	      </ul>
 	    </li>
 	  </ul>
-	</dd>	 
+	</dd>
         <dt id="REQ-Security-Access-Control">Security Access Control</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-interface-threat-unauthorized-wot-interface-access">WoT Interface Threat - Unauthorized WoT Interface Access</a></li>
-            <li>Categories Impacted:  
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Private-Information">Security Private Information</a></li>
 	      </ul>
@@ -8993,7 +8993,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-DOS">DOS: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-dos-threat">WoT DoS Threat</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9003,7 +9003,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-DDOS">DDOS: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-ddos-threat">WoT DDoS Threat</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9013,7 +9013,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-CTDA">CTDA: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-communication-threat-td-authenticity">WoT Communication Threat - TD Authenticity</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9023,7 +9023,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-CTDCP">CTDCP: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-communication-threat-td-confidentiality-and-privacy">WoT Communication Threat - TD Confidentiality and Privacy</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9033,7 +9033,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-CSUDA">CSUDA: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-communication-threat-system-user-data-authenticity">WoT Communication Threat - System User Data Authenticity</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9043,7 +9043,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-CSUDCP">CSUDCP: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy">WoT Communication Threat - System User Data Confidentiality and Privacy</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>
@@ -9053,7 +9053,7 @@ Therefore, various data for agricultural machinery management should be represen
 	<dt id="REQ-to-do-CSC">CSC: MITIGATIONS TO BE NAMED</dt><dd>
 	  <ul>
 	    <li>Related Risk: <a href="https://w3c.github.io/wot-security/#dfn-wot-communication-threat-side-channels">WoT Communication Threat - Side Channels</a></li>
-            <li>Categories Impacted: 
+            <li>Categories Impacted:
               <ul>
 		<li><a href="#CAT-Security-Public-Service">Security Public Service</a></li>
 	      </ul>

--- a/index.html
+++ b/index.html
@@ -2793,8 +2793,6 @@ Therefore, various data for agricultural machinery management should be represen
               <li>indoor coordinates</li>
             </ul>
 
-            There is no standard API specification for the WoT Thing Directory to maintain and query TDs.
-
           </dd>
           <dt>Existing Standards</dt>
           <dd>


### PR DESCRIPTION
While working on #242, I noticed that there is a leftover sentence in the document that states that there is no standard API specification for WoT TDDs "to maintain and query TDs". As there is an [API specification](https://www.w3.org/TR/wot-discovery/#directory-api-spec) included in the Discovery document by now, I think this sentence could be removed now which this PR proposes to do.

@farshidtz: Do you also think this gap has been closed? Or are there still gaps to fill in the API specification?