### PR TITLE
Update OAuth 2.0 section on ACE-OAuth

### DIFF
--- a/index.html
+++ b/index.html
@@ -7677,21 +7677,15 @@ Therefore, various data for agricultural machinery management should be represen
                 power/connectivity). </li>
             </ul>
           </dd>
-          <dd>Comment:
-            <ul>
-              <li>Investigate whether DTLS can be used.
-                Certainly the connection needs to be encrypted; this is required in the OAuth 2.0 specification.</li>
-              <li>Investigate whether protocols other than HTTP can be used, e.g. CoAP.
-                <ul>
-                  <li>found an interesting IETF draft RFC about CoAP support(encrypted using various mechanisms like
-                    DTLS
-                    or
-                    CBOR Object Signing and Encryption): <a
-                      href="https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-35">draft-ietf-ace-oauth</a></li>
-                </ul>
-              </li>
-            </ul>
-
+          <dd>
+            Constrained devices can be covered by this use-case by implementing
+            the authentication and authorization framework ACE-OAuth specified
+            in [[RFC9200]].
+            ACE-OAuth adapts OAuth 2.0 concepts to constrained environments with
+            the help of so-called profiles, which, for instance, enable the use
+            of CoAP with DTLS [[RFC9202]] or OSCORE [[RFC9203]].
+            However, the framework is also adaptable to other protocols such as
+            MQTT [[RFC9431]] by using a dedicated profile.
           </dd>
           <dt>Expected Data</dt>
           <dd>


### PR DESCRIPTION
In the context of the OAuth 2.0 use case, I noticed some (outdated) text regarding ACE-OAuth, an OAuth-based authentication and authorization framework for constrained environments. This PR updates the references and the text itself, turning the "comment" into a short paragraph pointing to the RFCs that have been published in the meantime.

I am not sure if this is already good enough, though, or whether this section should rather be removed and maybe even turned into its own use-case – let me know if you have any thoughts here :)

CC @mmccool @relu91


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-usecases/pull/248.html" title="Last updated on Nov 27, 2023, 11:52 PM UTC (b657397)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/248/d7ce713...JKRhb:b657397.html" title="Last updated on Nov 27, 2023, 11:52 PM UTC (b657397)">Diff</a>