### PR TITLE
Change the order of items of WoT-UseCases-Template.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
+++ b/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
@@ -8,7 +8,6 @@ body:
       value: |
         > [!Note]
         Thank you for proposing a new use case! Use case proposals use a structured GitHub issue so that we can semi-automate the process. A bot will check the suggestion after creation, and report on missing properties or other problems before we review the suggestion.
-
   - type: input
     id: submitter
     attributes:
@@ -21,11 +20,11 @@ body:
       value: |
         ## Motivation
   - type: textarea
-    id: what_to_be_done
+    id: Summary
     attributes:
-      label: "What to be done?"
+      label: "Summary"
       description: |
-        Please describe any problems or improvements you would like to make in your use case.
+        Please describe the summary of any problems or improvements you would like to make in your use case.
     validations:
       required: true
   - type: textarea
@@ -36,26 +35,23 @@ body:
         Please describe why you would like to use WoT in your use case.
     validations:
       required: true
-
   - type: markdown
     attributes:
       value: |
         ## Use Case Description and Expectations for stakeholders and environments
-
-
-  - type: textarea
-    id: description
-    attributes:
-      label: Description
-      description: "Please describe your use case details."
-    validations:
-      required: true
   - type: textarea
     id: gaps
     attributes:
       label: Gaps between the user's need and what's possible today
       description: |
         Describe any gaps that are not addressed in the current WoT standards and building blocks
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "Please describe your use case details."
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
+++ b/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: "Summary"
       description: |
-        Please describe the summary of any problems or improvements you would like to make in your use case.
+        Please summarize any problems or improvements you would like to make in your use case.
     validations:
       required: true
   - type: textarea
@@ -51,7 +51,7 @@ body:
     id: description
     attributes:
       label: Description
-      description: "Please describe your use case details."
+      description: "Please describe your use case in detail."
     validations:
       required: true
   - type: checkboxes


### PR DESCRIPTION
Based on the discussion results of ["What to be done?" is ambiguous #287](https://github.com/w3c/wot-usecases/issues/287), I change the order of item of WoT-UseCases-Template.yml.

Summary
Why WoT
Gaps
Description

I created PR [Change the order of items of sample-usecase-template.yml based Issue … #293](https://github.com/w3c/wot-usecases/pull/293). But this file was removed. This PR was closed. Then I create new PR. See also [Delete old issue templates #294](https://github.com/w3c/wot-usecases/pull/294)