### PR TITLE
New Use Case Template Proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -23,7 +23,8 @@ body:
     id: domain
     attributes:
       label: Domain or Industry
-      description: If your use case is from a specific domain, please identify it here.
+      description: If your use case is from a [specific domain](https://w3c.github.io/wot-usecases/#domains), please identify it here.
+      placeholder: Examples such as Smart Home, Factory Automation, Building Automation, Smart City, Agriculture are available in the link
     validations:
       required: false
   - type: textarea
@@ -38,6 +39,12 @@ body:
     attributes:
       label: WoT Usage
       description: How do you already use Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
+      value: |
+        Thing Description:
+        Discovery: 
+        Bindings: 
+        Profiles:
+        Scripting API
     validations:
       required: true
   - type: textarea
@@ -89,7 +96,7 @@ body:
     id: comments
     attributes:
       label: Comments
-      description: Do you have any other information you wish to provide?
+      description: Do you have any other information you wish to provide? If there are any security, privacy, accesibility or internationlization concerns, please provide them here.
     validations:
       required: false
   

--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -12,7 +12,7 @@ body:
     id: submitter
     attributes:
       label: Submitter Contact Information
-      description: Please enter your desired form of contact (e.g. Email, GitHub account name). Write "Separate" if you want to provide this in another way.
+      description: Please enter your desired form of contact (e.g., email, GitHub account name). Write "Separate" if you want to provide this in another way.
     validations:
       required: true
   - type: markdown
@@ -23,28 +23,28 @@ body:
     id: domain
     attributes:
       label: Domain or Industry
-      description: If your use case is from a specific domain, please provide here.
+      description: If your use case is from a specific domain, please identify it here.
     validations:
       required: false
   - type: textarea
     id: introduction
     attributes:
       label: Introduction
-      description: Give a basic, non-technical introduction of the use case
+      description: Give a basic, non-technical introduction to the use case.
     validations:
       required: true
   - type: textarea
     id: wot-usage
     attributes:
       label: WoT Usage
-      description: How do you already use the Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
+      description: How do you already use Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
       label: Technical Environment
-      description: What kind of protocols, devices, data types, existing standards are present in the environment of the use case?
+      description: What kind(s) of protocol, device, data type, and/or existing standard are present in the environment of the use case?
     validations:
       required: false
   - type: markdown
@@ -55,7 +55,7 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What is the problem you want to highlight with this use case? What is missing in the specifications? Remove irrelevant specifications.
+      description: What is the problem you want to highlight with this use case? What is missing in the specifications? (Remove irrelevant specifications from this list.)
       value: |
         Overall Problem:
         Missing part in the specifications:
@@ -78,7 +78,7 @@ body:
     id: solution
     attributes:
       label: Solution Proposal
-      description: Do you already have a technical solution in mind? Please provide example TDs, specification text, code or similar.
+      description: Do you already have a technical solution in mind? Please provide example TDs, specification text, code, or similar.
     validations:
       required: false
   - type: markdown
@@ -89,7 +89,7 @@ body:
     id: comments
     attributes:
       label: Comments
-      description: Do you have other information you wish to provide?
+      description: Do you have any other information you wish to provide?
     validations:
       required: false
   

--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -1,0 +1,95 @@
+name: Use Case Proposal for Gaps
+description: Use this template to provide a use case to motivate standardization work for a gap in the WoT specifications
+labels: ["UC"]
+title: "Provide a title for your use case..."
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!Note]
+        Thank you for proposing a new use case to motivate working on the gaps of WoT specifications! Use case proposals use a structured GitHub issue so that we can semi-automate the process. A bot will check the suggestion after creation, and report on missing properties or other problems before we review the suggestion.
+  - type: input
+    id: submitter
+    attributes:
+      label: Submitter Contact Information
+      description: Please enter your desired form of contact (e.g. Email, GitHub account name). Write "Separate" if you want to provide this in another way.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Background
+  - type: input
+    id: domain
+    attributes:
+      label: Domain or Industry
+      description: If your use case is from a specific domain, please provide here.
+    validations:
+      required: false
+  - type: textarea
+    id: introduction
+    attributes:
+      label: Introduction
+      description: Give a basic, non-technical introduction of the use case
+    validations:
+      required: true
+  - type: textarea
+    id: wot-usage
+    attributes:
+      label: WoT Usage
+      description: How do you already use the Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Technical Environment
+      description: What kind of protocols, devices, data types, existing standards are present in the environment of the use case?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ## Problem
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the problem you want to highlight with this use case? What is missing in the specifications? Remove irrelevant specifications.
+      value: |
+        Overall Problem:
+        Missing part in the specifications:
+        - Thing Description
+        - Discovery: 
+        - Bindings:
+        - Profiles:
+        - Scripting API:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: expectation
+    attributes:
+      label: Expectation
+      description: How should this problem be solved? What is your expectation for the specifications to include?
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution Proposal
+      description: Do you already have a technical solution in mind? Please provide example TDs, specification text, code or similar.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ## Other
+  - type: textarea
+    id: comments
+    attributes:
+      label: Comments
+      description: Do you have other information you wish to provide?
+    validations:
+      required: false
+  


### PR DESCRIPTION
After talking with @chachamimm , I would like to provide a new use case template based on my experience in writing #296 and my expectations as a spec editor. This one specifically focuses on identifying gaps, which is my interest as a spec editor. 

This can seem a bit radical since it does not contain a lot of the fields present in the other use case templates we have seen so far. 

My main goal in this new template is addressing the following:

A use case submission should come from someone with the question of “I want to make sure that {my use case} is possible with WoT. However, due to lack of {gap}, I am not able to solve this in a standardized way.”

Since we need to assess the use case, we need more information:

- Some information about the background of the use case, such as some text, Industry or Domain
- How WoT is already used: TDs, Discovery, Bindings, Profile, Scripting
- Problem and Gap