### PR TITLE
perl script for Automate Conversion of US/UC/UCC from MD to HTML

### DIFF
--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -69,7 +69,8 @@ while (<IN>) {
         print "</ul>\n";
         $is_list = 0;
     }
-    if (/^```/) {
+    if (/^```json/ && /^```js/) {
+      print "<code>\n";
     } else {
         print "$_\n";
     }

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+my $src = "";
+my $id = "";
+my $title = "";
+my $section = "";
+my $section_id = "";
+my $is_list = 0;
+my $topic = "";
+my $current_level = 0;
+my $prev_level = 0;
+
+$src = $ARGV[0];
+$id = $src;
+$id  =~ s/\.md$//;
+
+open(IN, ${src}) || die "${src}: $!\n";
+while (<IN>) {
+  chomp;
+  s/</&lt;/g;
+  s/>/&gt;/g;
+  s/\r$//;
+
+  while ($_ =~ /\[.*\]\(.*\)/g) {
+    $_ =~ s/\[(.*)\]\((.*)\)/<a href="$2">$1<\/a>/;
+  }
+
+  if (/^## Title: (.*)$/) {
+    $current_level = 2;
+    ${title} = $1;
+    print "<section id=\"${id}\">\n";
+    print "<h2>${title}</h2>\n";
+    print "<dl>\n";
+    $is_list = 0;
+
+  } elsif (/^### (.*)$/) {
+    $current_level = 3;
+    ${section} = $1;
+    ${section} =~ s/:([\s]+|)$//;
+
+    ${section_id} = $section;
+    ${section_id} =~ s/\(s\)//;
+    ${section_id} =~ tr/A-Z/a-z/;
+
+    ${id} =~ tr/A-Z/a-z/;
+
+    if ($prev_level >= $current_level) {
+      print "<\/dd>\n";
+    }
+    print "<dt>${section}</dt>\n";
+    print "<dd>\n";
+    $prev_level = $current_level;
+    $is_list = 0;
+
+  } elsif (/^#### (.*)$/) {
+    print "<p>$_</p>\n";
+    $is_list = 0;
+
+  } elsif (/^(\-|\*) (.*)$/) {
+    ${topic} = $2;
+    if ($is_list eq 0) {
+      print "<ul>\n";
+    }
+    print "<li>${topic}</li>\n";
+    $is_list = 1;
+
+  } else {
+    if (($is_list eq 1) && (/^$/)) {
+        print "</ul>\n";
+        $is_list = 0;
+    }
+    if (/^```/) {
+    } else {
+        print "$_\n";
+    }
+  }
+}
+
+print "<\/dd>\n";
+print "<\/dl>\n";
+print "<\/section>\n";
+close(IN);

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -69,6 +69,9 @@ while (<IN>) {
         print "</ul>\n";
         $is_list = 0;
     }
+    if (/^```/) {
+      print "</code>\n";
+    }
     if (/^```json/ && /^```js/) {
       print "<code>\n";
     } else {

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -9,6 +9,8 @@ my $is_list = 0;
 my $topic = "";
 my $current_level = 0;
 my $prev_level = 0;
+my $code = 0;
+my $title_flag = 0;
 
 $src = $ARGV[0];
 $id = $src;
@@ -32,7 +34,18 @@ while (<IN>) {
     print "<h2>${title}</h2>\n";
     print "<dl>\n";
     $is_list = 0;
-
+  if (/^### Identifier/) {
+    $title_flag = 1;
+  } elsif ( $title_flag eq 1 ) {
+    if ( /^\w/ ) {
+      $current_level = 2;
+      ${title} = $_;
+      print "<section id=\"${id}\">\n";
+      print "<h3>${title}</h>\n";
+      print "<dl>\n";
+      $is_list = 0;
+      $title_flag = 0;
+      }
   } elsif (/^### (.*)$/) {
     $current_level = 3;
     ${section} = $1;
@@ -69,13 +82,21 @@ while (<IN>) {
         print "</ul>\n";
         $is_list = 0;
     }
-    if (/^```/) {
-      print "</code>\n";
-    }
-    if (/^```json/ && /^```js/) {
-      print "<code>\n";
-    } else {
-        print "$_\n";
+
+  } elsif (($is_list eq 1) && (/^$/)) {
+    print "</ul>\n";
+    $is_list = 0;
+  } elsif ( (/^```json/) || (/^```js/)) {
+    print "<code>\n";
+    $code = 1;
+  } elsif ( ($code eq 1 ) && (/^```/) ) {
+    print "</code>\n";
+    $code = 0;
+  } elsif ( ($code eq 1 )) {
+    print "$_\n";
+  } else {
+    if ( /^\w/ ) {
+      print "$_\n";
     }
   }
 }

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -38,7 +38,7 @@ while (<IN>) {
       print "<dl>\n";
       $is_list = 0;
       $title_flag = 0;
-      }
+    }
   } elsif (/^### (.*)$/) {
     $current_level = 3;
     ${section} = $1;

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -34,7 +34,7 @@ while (<IN>) {
       $current_level = 2;
       ${title} = $_;
       print "<section id=\"${id}\">\n";
-      print "<h3>${title}</h>\n";
+      print "<h3>${title}</h3>\n";
       print "<dl>\n";
       $is_list = 0;
       $title_flag = 0;

--- a/CONTRIBUTIONS/md2html_YAML.pl
+++ b/CONTRIBUTIONS/md2html_YAML.pl
@@ -27,13 +27,6 @@ while (<IN>) {
     $_ =~ s/\[(.*)\]\((.*)\)/<a href="$2">$1<\/a>/;
   }
 
-  if (/^## Title: (.*)$/) {
-    $current_level = 2;
-    ${title} = $1;
-    print "<section id=\"${id}\">\n";
-    print "<h2>${title}</h2>\n";
-    print "<dl>\n";
-    $is_list = 0;
   if (/^### Identifier/) {
     $title_flag = 1;
   } elsif ( $title_flag eq 1 ) {
@@ -76,13 +69,6 @@ while (<IN>) {
     }
     print "<li>${topic}</li>\n";
     $is_list = 1;
-
-  } else {
-    if (($is_list eq 1) && (/^$/)) {
-        print "</ul>\n";
-        $is_list = 0;
-    }
-
   } elsif (($is_list eq 1) && (/^$/)) {
     print "</ul>\n";
     $is_list = 0;


### PR DESCRIPTION
Based on [Issue #326](https://github.com/w3c/wot-usecases/issues/326), I have made changes to the perl script from md2html.pl for automatic conversion from US/UC/UCC MD to HTML.