### PR TITLE
Turn bullet points in use case template into subsections

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -40,11 +40,25 @@ body:
       label: WoT Usage
       description: How do you already use Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
       value: |
-        Thing Description:
-        Discovery: 
-        Bindings: 
-        Profiles:
-        Scripting API
+        #### Thing Description
+
+
+
+        #### Discovery
+
+
+
+        #### Bindings
+
+
+
+        #### Profiles
+
+
+
+        #### Scripting API
+
+
     validations:
       required: true
   - type: textarea
@@ -64,14 +78,33 @@ body:
       label: Problem
       description: What is the problem you want to highlight with this use case? What is missing in the specifications? (Remove irrelevant specifications from this list.)
       value: |
-        Overall Problem:
-        Missing part in the specifications:
-        - Thing Description
-        - Discovery: 
-        - Bindings:
-        - Profiles:
-        - Scripting API:
-      render: markdown
+        #### Overall Problem
+
+
+
+        #### Missing part in the specifications
+
+
+
+        #### Thing Description
+
+
+
+        #### Discovery
+
+
+
+        #### Bindings
+
+
+
+        #### Profiles
+
+
+
+        #### Scripting API
+
+
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -76,33 +76,33 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What is the problem you want to highlight with this use case? What is missing in the specifications? (Remove irrelevant specifications from this list.)
+      description: What is the problem you want to highlight with this use case? What is missing in the specifications? Remove irrelevant specifications from the list under "Missing parts of the specifications".
       value: |
         #### Overall Problem
 
 
 
-        #### Missing part in the specifications
+        #### Missing parts of the specifications
 
 
 
-        #### Thing Description
+        ##### Thing Description
 
 
 
-        #### Discovery
+        ##### Discovery
 
 
 
-        #### Bindings
+        ##### Bindings
 
 
 
-        #### Profiles
+        ##### Profiles
 
 
 
-        #### Scripting API
+        ##### Scripting API
 
 
     validations:

--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -38,7 +38,7 @@ body:
     id: wot-usage
     attributes:
       label: WoT Usage
-      description: How do you already use Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".
+      description: How do you already use Web of Things specifications such as Thing Description, Discovery, Bindings, Profiles, Scripting API? If you are not using WoT, please write "None".  Delete any sections that are not relevant.
       value: |
         #### Thing Description
 


### PR DESCRIPTION
Filling out the use case template, I got the impression that the way the specifications are currently listed in the text areas (as bullet points) is not really ideal and partially inconsistent. This PR suggests changing the template to ask the user to provide their input under subsections instead, making the content easier to navigate after submission.