### PR TITLE
Fix typos in use case template

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case-template.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-template.yml
@@ -96,7 +96,7 @@ body:
     id: comments
     attributes:
       label: Comments
-      description: Do you have any other information you wish to provide? If there are any security, privacy, accesibility or internationlization concerns, please provide them here.
+      description: Do you have any other information you wish to provide? If there are any security, privacy, accessibility or internationalization concerns, please provide them here.
     validations:
       required: false
-  
+


### PR DESCRIPTION
Editing the use case template, I've noticed two small typos. This PR proposes a fix.