### PR TITLE
fix: don't render user story fields as Markdown code blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story-template.yaml
+++ b/.github/ISSUE_TEMPLATE/user-story-template.yaml
@@ -45,7 +45,6 @@ body:
       description: |
           Other stakeholders that may be impacted.  Use a markdown list, with one stakeholder per line,
           providing definitions in the Details field if necessary.
-      render: markdown
     validations:
       required: false
   - type: textarea
@@ -56,7 +55,6 @@ body:
           Additional information on the stakeholders, if required.
           If any stakeholder is not one already defined in the document, propose a definition (if a user role)
           or a link (if an organization, such as an SDO).
-      render: markdown
     validations:
       required: false
   - type: markdown
@@ -83,7 +81,6 @@ body:
          capability already exists (if you are documenting the requirements for an existing feature)
          or link to an issue or MD file describing the technical details for a feature if the
          feature does not yet exist but is to be proposed.
-      render: markdown
     validations:
       required: false
   - type: markdown
@@ -106,7 +103,6 @@ body:
         Any additional details needed to better explain the purpose of the
         proposed capability.  If there are multiple reasons for a particular
         capability provide them as a list.
-      render: markdown
     validations:
       required: false
   - type: textarea
@@ -117,8 +113,5 @@ body:
         Provide links to one or more motivating Use Cases or Use Case Categories.
         If a new Use Case or Use Case Category is needed submit separate issues
         and link to these issues, otherwise link to corresponding sections in the document.
-      render: markdown
     validations:
       required: true
-
-  

--- a/.github/ISSUE_TEMPLATE/user-story-template.yaml
+++ b/.github/ISSUE_TEMPLATE/user-story-template.yaml
@@ -2,6 +2,8 @@ name: User Story Proposal
 description: |
   Use this template to provide a User Story for a WoT requirement,
   connecting motivating use cases to features.
+  If you want to insert code or json examples in markdown as code blocks,
+  please use "```js" or "```json" at the start and "```" at the end.
 labels: ["US"]
 title: "Provide a concise title for your user story (will be used to form an id)."
 body:


### PR DESCRIPTION
Filling out the user story template, I noticed that some of the fields currently end up being rendered as Markdown code blocks, which is probably not intended (see https://github.com/JKRhb/wot-usecases/issues/1). This PR slightly adjusts the template, removing the lines in the template that cause this behavior.