### PR TITLE
Fixed typo ( Maintainter to Maintainer) in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -9836,7 +9836,7 @@ Therefore, various data for agricultural machinery management should be represen
             <dt>Other Stakeholders</dt>
             <dd>
               <a href="#STAKEHOLDER-System-Integrator">System Integrator</a>,
-	            <a href="#STAKEHOLDER-System-Maintainter">System Maintainer</a>
+	            <a href="#STAKEHOLDER-System-Maintainer">System Maintainer</a>
             </dd>
           </dl>
         </dd>
@@ -10025,7 +10025,7 @@ Therefore, various data for agricultural machinery management should be represen
             <dt>Other Stakeholders</dt>
             <dd>
               <a href="#STAKEHOLDER-System-Integrator">System Integrator</a>,
-	      <a href="#STAKEHOLDER-System-Maintainter">System Maintainer</a>
+	      <a href="#STAKEHOLDER-System-Maintainer">System Maintainer</a>
             </dd>
           </dl>
         </dd>
@@ -10074,7 +10074,7 @@ Therefore, various data for agricultural machinery management should be represen
             <dt>Other Stakeholders</dt>
             <dd>
               <a href="#STAKEHOLDER-System-Integrator">System Integrator</a>,
-	            <a href="#STAKEHOLDER-System-Maintainter">System Maintainer</a>
+	            <a href="#STAKEHOLDER-System-Maintainer">System Maintainer</a>
             </dd>
           </dl>
         </dd>


### PR DESCRIPTION
There is a ReSpec Error. So I fixed typo in index.html following:

  #STAKEHOLDER-System-Maintainter -> #STAKEHOLDER-System-Maintainer


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/368.html" title="Last updated on Jul 9, 2025, 2:26 AM UTC (34badd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/368/2ee113a...34badd3.html" title="Last updated on Jul 9, 2025, 2:26 AM UTC (34badd3)">Diff</a>