### PR TITLE
Reorganize Intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,15 @@
           }]
         }],
       localBiblio: {
-        "ISO-6709": {
+        "SWEBOKv4": {
+          title: "Guide to the Software Engineering Body of Knowledge (SWEBOK Guide), Version 4.0",
+	  authors: "Hironori Washizaki",
+          href: "https://www.swebok.org/",
+          status: "Published",
+          date: "2024",
+          publisher: "IEEE Computer Society"
+        },        
+	"ISO-6709": {
           title: "ISO-6709:2008 : Standard representation of geographic point location by coordinates",
           href: "https://www.iso.org/standard/39242.html",
           status: "Published",
@@ -350,7 +358,7 @@
 	<dt>Use Case:</dt><dd>A use case is a documented scenario that achieves a specific set of goals for specific users that the WoT should support. Ideally, use cases identify specific needed functionality or gaps in current standards.</dd>
 
 	<dt>Use Case Category:</dt><dd>A Use Case Category is a set of Use Cases with a common property. These are used to group Use Cases so they can be referred to easily when defining requirements, i.e., User Stories.</dd>
-	<dt>Requirement:</dt><dd>A Requirement is a condition or capability needed by a user to solve a problem or acheive an objective; it may also be a condition or capability that must be met or possessed by a system or system component to satisfy another formally imposed document, such as an external standard [swebokv4].</dd>
+	<dt>Requirement:</dt><dd>A Requirement is a condition or capability needed by a user to solve a problem or acheive an objective; it may also be a condition or capability that must be met or possessed by a system or system component to satisfy another formally imposed document, such as an external standard [[SWEBOKv4]].</dd>
 
 	<dt>User Story:</dt><dd>A User Story relates a specific feature or set of features (or proposed features) in the WoT specifications with its motivation, which may reference a Use Case. User stories summarize both functional requirements (the purpose) and technical requirements (the feature), and also indicate the stakeholder that requires the feature.  User stories can be expressed in a sentence of the form: "As a STAKEHOLDER I need a FEATURE so that PURPOSE."  User Stories are not detailed requirements; these should be maintained elsewhere, for example by the responsible Task Force, with the User Story linking to them.</dd>
 


### PR DESCRIPTION
- Flatten section structure so e.g. terminology is not nested (issue #370)
- Simplify domain list (we don't need details, they are in the section headers) so basic links kept, but not details (rather than just deleting it as suggested in #369)
- Put in placeholders for terms used with a special meaning (like use cases and user stories) under terminology (only terms not defined in Architecture)

resolves #370 
resolves #369


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/371.html" title="Last updated on Jul 16, 2025, 11:22 AM UTC (3cf3dd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/371/13e24d3...3cf3dd7.html" title="Last updated on Jul 16, 2025, 11:22 AM UTC (3cf3dd7)">Diff</a>