### PR TITLE
Add Context to Use Case definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
         This document uses the terminology from WoT Architecture [[wot-architecture]].
 	In addition, the following terms are used with the defined meanings:
 	<dl>
-	<dt>Use Case:</dt><dd>A use case is a documented scenario that achieves a specific set of goals for specific users that the WoT should support. Ideally, use cases identify specific needed functionality or gaps in current standards.</dd>
+	<dt>Use Case:</dt><dd>A use case is a documented scenario that achieves a specific set of goals for specific users that the WoT should support. The purpose of a Use Case is to put required features and usages of WoT standards in context. Ideally, use cases identify specific needed functionality or gaps in current standards.</dd>
 
 	<dt>Use Case Category:</dt><dd>A Use Case Category is a set of Use Cases with a common property. These are used to group Use Cases so they can be referred to easily when defining requirements, i.e., User Stories.</dd>
 	<dt>Requirement:</dt><dd>A Requirement is a condition or capability needed by a user to solve a problem or acheive an objective; it may also be a condition or capability that must be met or possessed by a system or system component to satisfy another formally imposed document, such as an external standard [[SWEBOKv4]].</dd>


### PR DESCRIPTION
- after discussion, kept the "Ideally..." sentence, even though it's a bit aspirational
- added sentence about "purpose is... to provide context"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/374.html" title="Last updated on Jul 23, 2025, 11:26 AM UTC (490c499)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/374/77c9792...490c499.html" title="Last updated on Jul 23, 2025, 11:26 AM UTC (490c499)">Diff</a>