### PR TITLE
To change items in the Terminology section

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@
           <dfn data-lt="Stakeholder Device Manufacturer" class="lint-ignore" >Device Manufacturer</dfn>
         </dt>
         <dd>
-          An individual, company, or organization that design and develop networked or IoT devices to be sold to consumers.
+          An individual, company, or organization that designs and develops networked or IoT devices to be sold to consumers.
         </dd>
         <dt>
           <dfn date-lt="Stakeholder System Provider" class="lint-ignore">System Provider</dfn>
@@ -11562,6 +11562,7 @@ Therefore, various data for agricultural machinery management should be represen
 </body>
 
 </html>
+
 
 
 


### PR DESCRIPTION
Based on [Issue #366](https://github.com/w3c/wot-usecases/issues/366), I created a new PR to change the placement of items related to stakeholders in the Terminology Section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/380.html" title="Last updated on Aug 20, 2025, 11:55 AM UTC (5827bd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/380/72e6b4b...5827bd3.html" title="Last updated on Aug 20, 2025, 11:55 AM UTC (5827bd3)">Diff</a>