### PR TITLE
To move inactive editors to "formerEditors" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,31 +21,29 @@
       githubAPI: "https://api.github.com/repos/w3c/wot-usecases/",
       issueBase: "https://www.github.com/w3c/wot-usecases/issues",
       editors: [{
-        name: "Michael Lagally",
-        w3cid: "47166",
-        company: "Oracle Corp.",
-        companyURL: "https://www.oracle.com/"
-      },
-      {
         name: "Michael McCool",
         w3cid: "93137",
         company: "Intel Corp.",
         companyURL: "https://www.intel.com/"
       },
       {
-        name: "Ryuichi Matsukura",
-        w3cid: "64284",
-        company: "Fujitsu Ltd.",
-        companyURL: "https://www.fujitsu.com/"
-      },
-      {
         name: "Tomoaki Mizushima",
         w3cid: "98915",
         company: "Internet Research Institute, Inc.",
         companyURL: "https://www.iri.co.jp/"
-      }
-      ],
-
+      }],
+	  formerEditors: [{
+        name: "Michael Lagally",
+        w3cid: "47166",
+        company: "Oracle Corp.",
+        companyURL: "https://www.oracle.com/"
+      },
+      {
+        name: "Ryuichi Matsukura",
+        w3cid: "64284",
+        company: "Fujitsu Ltd.",
+        companyURL: "https://www.fujitsu.com/"
+      }],
       otherLinks: [
         {
           key: "Contributors",
@@ -11449,6 +11447,7 @@ Therefore, various data for agricultural machinery management should be represen
 </body>
 
 </html>
+
 
 
 


### PR DESCRIPTION
Based on [Issue #378](https://github.com/w3c/wot-usecases/issues/378), I created a new PR to move inactive editors ( Michael Lagally and Ryuichi Matsukura) to "formerEditors" section.