### PR TITLE
To fix comment out of in the "3.10.1.1 Media Use Cases" chapter of in…

### DIFF
--- a/index.html
+++ b/index.html
@@ -8370,7 +8370,7 @@ Therefore, various data for agricultural machinery management should be represen
       <section id="audio_video">
       <h2>Audio/Video</h2>
       <!--
-      <section id="UC-media-use-cases-1"> <!-- old id: media-information-references -->
+      <section id="UC-media-use-cases-1">
         <h2>Media Use Cases</h2>
         <dl>
 
@@ -11533,6 +11533,7 @@ Therefore, various data for agricultural machinery management should be represen
 </body>
 
 </html>
+
 
 
 


### PR DESCRIPTION
There was a description for commenting out the “3.10.1.1 Media Use Cases” section in index.html, but it did not work. Because the comment out cannot be nested.

I fixed it.

If this chapter is not necessary, it may be better to delete it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/pull/382.html" title="Last updated on Aug 15, 2025, 3:26 AM UTC (3969d25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-usecases/382/2963847...3969d25.html" title="Last updated on Aug 15, 2025, 3:26 AM UTC (3969d25)">Diff</a>